### PR TITLE
#38: Preparing LocalDocker for testing

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Docker.java
+++ b/src/main/java/com/amihaiemil/docker/Docker.java
@@ -60,7 +60,7 @@ public interface Docker {
      * Entry point for the Networks API.
      * @return Networks.
      */
-    Networks networs();
+    Networks networks();
 
     /**
      * Entry point for the Volumes API.

--- a/src/main/java/com/amihaiemil/docker/LocalDocker.java
+++ b/src/main/java/com/amihaiemil/docker/LocalDocker.java
@@ -27,6 +27,7 @@ package com.amihaiemil.docker;
 
 import java.io.File;
 import java.net.URI;
+import org.apache.http.client.HttpClient;
 
 /**
  * Local Docker API. Use this when you want to communicate with the local
@@ -58,10 +59,19 @@ public final class LocalDocker extends RtDocker {
      * @param version API version (e.g. v1.30).
      */
     public LocalDocker(final File unixSocket, final String version){
-        super(
+        this(
             new UnixHttpClient(unixSocket),
             URI.create("unix://localhost:80/" + version)
         );
+    }
+
+    /**
+     * Local Docker engine.
+     * @param client The http client to use.
+     * @param baseUri Base URI.
+     */
+    LocalDocker(final HttpClient client, final URI baseUri) {
+        super(client, baseUri);
     }
 
 }

--- a/src/main/java/com/amihaiemil/docker/LocalDocker.java
+++ b/src/main/java/com/amihaiemil/docker/LocalDocker.java
@@ -59,19 +59,16 @@ public final class LocalDocker extends RtDocker {
      * @param version API version (e.g. v1.30).
      */
     public LocalDocker(final File unixSocket, final String version){
-        this(
-            new UnixHttpClient(unixSocket),
-            URI.create("unix://localhost:80/" + version)
-        );
+        this(new UnixHttpClient(unixSocket), version);
     }
 
     /**
      * Local Docker engine.
      * @param client The http client to use.
-     * @param baseUri Base URI.
+     * @param version API version (e.g. v1.30).
      */
-    LocalDocker(final HttpClient client, final URI baseUri) {
-        super(client, baseUri);
+    LocalDocker(final HttpClient client, final String version) {
+        super(client, URI.create("unix://localhost:80/" + version));
     }
 
 }

--- a/src/main/java/com/amihaiemil/docker/RtDocker.java
+++ b/src/main/java/com/amihaiemil/docker/RtDocker.java
@@ -81,7 +81,7 @@ abstract class RtDocker implements Docker {
     }
 
     @Override
-    public final Networks networs() {
+    public final Networks networks() {
         return null;
     }
 

--- a/src/test/java/com/amihaiemil/docker/LocalDockerTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/LocalDockerTestCase.java
@@ -36,10 +36,6 @@ import java.io.File;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
- * @todo #39:1h Implement a unix socket server so we can also unit
- *  test the calls made with UnixHttpClient. The user should be able
- *  to specify what response it expected with each request to a certain
- *  path.
  */
 public final class LocalDockerTestCase {
 

--- a/src/test/java/com/amihaiemil/docker/UnixHttpClientTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/UnixHttpClientTestCase.java
@@ -47,6 +47,9 @@ import java.io.IOException;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
+ * @todo #38:30min Implement a unix socket server so that we can also test
+ *  the calls made with UnixHttpClient. The user should be able to specify
+ *  what response it expected with each request to a certain path.
  */
 public final class UnixHttpClientTestCase {
 

--- a/src/test/java/com/amihaiemil/docker/mock/AssertRequest.java
+++ b/src/test/java/com/amihaiemil/docker/mock/AssertRequest.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2018, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.amihaiemil.docker.mock;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Predicate;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.params.HttpParams;
+import org.apache.http.protocol.HttpContext;
+import org.junit.Assert;
+
+/**
+ * Asserts that a {@link HttpRequest} meets certain conditions specified by the
+ * user. If successful, a response predetermined by the user is returned,
+ * otherwise it {@link Assert#fail() fails}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @version $Id$
+ * @since 0.0.1
+ * @todo #38:30min Figure out how to let the user specify the failure message
+ *  for each condition in case a test on the request fails. This way, if the
+ *  request does not meet a given condition, then the test's error will show the
+ *  reason why it didn't.
+ */
+public final class AssertRequest implements HttpClient {
+    /**
+     * The response to return if all conditions are met.
+     */
+    private final HttpResponse response;
+    /**
+     * Conditions against which to validate requests.
+     */
+    private final Collection<Predicate<HttpRequest>> conditions;
+
+    /**
+     * Ctor.
+     *
+     * @param response The response that should be returned if all conditions
+     * are met.
+     * @param conditions The conditions that the http request must satisfy.
+     */
+    @SuppressWarnings("unchecked")
+    public AssertRequest(final HttpResponse response,
+        final Predicate<HttpRequest>... conditions) {
+        this.response = response;
+        this.conditions = Arrays.asList(conditions);
+    }
+
+    @Override
+    public HttpParams getParams() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public ClientConnectionManager getConnectionManager() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public HttpResponse execute(final HttpUriRequest request)
+        throws IOException, ClientProtocolException {
+        this.check(request);
+        return this.response;
+    }
+
+    @Override
+    public HttpResponse execute(final HttpUriRequest request,
+        final HttpContext context)
+        throws IOException, ClientProtocolException {
+        this.check(request);
+        return this.response;
+    }
+
+    @Override
+    public HttpResponse execute(final HttpHost target,
+        final HttpRequest request)
+        throws IOException, ClientProtocolException {
+        this.check(request);
+        return this.response;
+    }
+
+    @Override
+    public HttpResponse execute(final HttpHost target,
+        final HttpRequest request, final HttpContext context)
+        throws IOException, ClientProtocolException {
+        this.check(request);
+        return this.response;
+    }
+
+    @Override
+    public <T> T execute(final HttpUriRequest request,
+        final ResponseHandler<? extends T> responseHandler)
+        throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public <T> T execute(final HttpUriRequest request,
+        final ResponseHandler<? extends T> responseHandler,
+        final HttpContext context)
+        throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public <T> T execute(final HttpHost target, final HttpRequest request,
+        final ResponseHandler<? extends T> responseHandler)
+        throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    //@checkstyle ParameterNumber (8 lines)
+    @Override
+    public <T> T execute(final HttpHost target, final HttpRequest request,
+        final ResponseHandler<? extends T> responseHandler,
+        final HttpContext context)
+        throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    /**
+     * Checks all conditions against the request.
+     *
+     * @param request The request.
+     */
+    private void check(final HttpRequest request) {
+        this.conditions.forEach(cond -> {
+            if (!cond.test(request)) {
+                Assert.fail();
+            }
+        });
+    }
+}


### PR DESCRIPTION
as per #38:

This PR:
* Added primary ctor to `LocalDocker`
* Added `AssertRequest`, a mock HttpClient useful for testing requests
* Fixed typo in interface `Docker`
* Reduces the scope of the puzzle of "create a unix socket server" to just the testing of `UnixHttpClient`
* Leaves a puzzle to advance the design of `AssertRequest`