### PR TITLE
(#44) Changed ConnectionManager for UnixHttpClient

### DIFF
--- a/src/test/java/com/amihaiemil/docker/UnixHttpClientITCase.java
+++ b/src/test/java/com/amihaiemil/docker/UnixHttpClientITCase.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2018, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.amihaiemil.docker;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Integration tests for {@link UnixHttpClient}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @version $Id$
+ * @since 0.0.1
+ */
+public final class UnixHttpClientITCase {
+    /**
+     * UnixHttpClient can be executed more than once without throwing a
+     * ConnectionPoolTimeoutException, demonstrating its connection-pooling
+     * capabilities.
+     * @throws IOException unexpected
+     * @see <a href="https://github.com/amihaiemil/docker-java-api/issues/44">bug</a>
+     * @todo #44:30min This should be un-ignored and refactored after #41 is
+     *  done. The unix socket server needs to be spooled up, and the url
+     *  changed accordingly.
+     */
+    @Ignore
+    @Test
+    public void canBeReused() throws IOException {
+        final HttpClient client = new UnixHttpClient(
+            new File("/var/run/docker.sock")
+        );
+        client.execute(new HttpGet("http://localhost/ping"));
+        client.execute(new HttpGet("http://localhost/ping"));
+    }
+}


### PR DESCRIPTION
This PR:
* Solves #44 
* `UnixHttpClient`: swapped BasicHttpClientConnectionManager for PoolingHttpClientConnectionManager
* Leaves puzzle due to impediment on #41 
* Leaves puzzle to make the pool size configurable