### PR TITLE
(#52) Configuration of Unix connection pooling

### DIFF
--- a/src/main/java/com/amihaiemil/docker/LocalDocker.java
+++ b/src/main/java/com/amihaiemil/docker/LocalDocker.java
@@ -36,6 +36,10 @@ import org.apache.http.client.HttpClient;
  * <pre>
  *     final Docker docker = new LocalDocker("unix:///var/run/dicker.sock");
  * </pre>
+ * 
+ * This implementation manages an internal pool of 10 http connections. Users
+ * who wish to alter this behaviour may provide their own {@link HttpClient}
+ * via {@link #LocalDocker(HttpClient, String)}.
  *
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
@@ -64,10 +68,14 @@ public final class LocalDocker extends RtDocker {
 
     /**
      * Local Docker engine.
+     * <p>
+     * Users may supply their own {@link HttpClient} that must register a unix
+     * socket factory.
      * @param client The http client to use.
      * @param version API version (e.g. v1.30).
+     * @see UnixSocketFactory
      */
-    LocalDocker(final HttpClient client, final String version) {
+    public LocalDocker(final HttpClient client, final String version) {
         super(client, URI.create("unix://localhost:80/" + version));
     }
 

--- a/src/main/java/com/amihaiemil/docker/LocalDocker.java
+++ b/src/main/java/com/amihaiemil/docker/LocalDocker.java
@@ -69,11 +69,10 @@ public final class LocalDocker extends RtDocker {
     /**
      * Local Docker engine.
      * <p>
-     * Users may supply their own {@link HttpClient} that must register a unix
-     * socket factory.
+     * Users may supply their own {@link HttpClient} that must register a
+     * {@link UnixSocketFactory}.
      * @param client The http client to use.
      * @param version API version (e.g. v1.30).
-     * @see UnixSocketFactory
      */
     public LocalDocker(final HttpClient client, final String version) {
         super(client, URI.create("unix://localhost:80/" + version));

--- a/src/main/java/com/amihaiemil/docker/UnixHttpClient.java
+++ b/src/main/java/com/amihaiemil/docker/UnixHttpClient.java
@@ -50,8 +50,6 @@ import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
  * @since 0.0.1
  * @checkstyle ParameterNumber (150 lines)
  * @checkstyle AnonInnerLength (150 lines)
- * @todo #44:30min Connection pooling is currently hardcoded at 10 connections
- *  max. Figure out how to make this configurable.
  */
 final class UnixHttpClient implements HttpClient {
 

--- a/src/main/java/com/amihaiemil/docker/UnixHttpClient.java
+++ b/src/main/java/com/amihaiemil/docker/UnixHttpClient.java
@@ -25,8 +25,6 @@
  */
 package com.amihaiemil.docker;
 
-import jnr.unixsocket.UnixSocketAddress;
-import jnr.unixsocket.UnixSocketChannel;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
@@ -41,8 +39,6 @@ import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HttpContext;
 import java.io.File;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.util.function.Supplier;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 
@@ -74,32 +70,7 @@ final class UnixHttpClient implements HttpClient {
                 new PoolingHttpClientConnectionManager(
                     RegistryBuilder
                         .<ConnectionSocketFactory>create()
-                        .register(
-                            "unix",
-                            new ConnectionSocketFactory() {
-                                @Override
-                                public Socket createSocket(
-                                    final HttpContext httpContext
-                                ) throws IOException {
-                                    return UnixSocketChannel.open().socket();
-                                }
-
-                                @Override
-                                public Socket connectSocket(
-                                    final int connectionTimeout,
-                                    final Socket socket,
-                                    final HttpHost host,
-                                    final InetSocketAddress remoteAddress,
-                                    final InetSocketAddress localAddress,
-                                    final HttpContext context
-                                ) throws IOException {
-                                    socket.setSoTimeout(connectionTimeout);
-                                    socket.getChannel().connect(
-                                        new UnixSocketAddress(socketFile)
-                                    );
-                                    return socket;
-                                }
-                            })
+                        .register("unix", new UnixSocketFactory(socketFile))
                         .build()
                 );
             pool.setDefaultMaxPerRoute(10);

--- a/src/main/java/com/amihaiemil/docker/UnixSocketFactory.java
+++ b/src/main/java/com/amihaiemil/docker/UnixSocketFactory.java
@@ -1,0 +1,51 @@
+package com.amihaiemil.docker;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixSocketChannel;
+import org.apache.http.HttpHost;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * Provides unix sockets connecting to a given unix socket file.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @version $Id$
+ * @since 0.0.1
+ * @checkstyle ParameterNumber (100 lines)
+ */
+public final class UnixSocketFactory implements ConnectionSocketFactory {
+    /**
+     * File pointing to the unix socket.
+     */
+    private final File unixSocket;
+
+    /**
+     * Ctor.
+     * @param unixSocket File pointing to the unix socket.
+     */
+    public UnixSocketFactory(final File unixSocket) {
+        this.unixSocket = unixSocket;
+    }
+
+    @Override
+    public Socket createSocket(final HttpContext context) throws IOException {
+        return UnixSocketChannel.open().socket();
+    }
+
+    @Override
+    public Socket connectSocket(final int connectTimeout, final Socket socket,
+        final HttpHost host, final InetSocketAddress remoteAddress,
+        final InetSocketAddress localAddress, final HttpContext context)
+        throws IOException {
+        socket.setSoTimeout(connectTimeout);
+        socket.getChannel().connect(
+            new UnixSocketAddress(this.unixSocket)
+        );
+        return socket;
+    }
+}


### PR DESCRIPTION
This PR:
* solves #52 
* Externalizes the anonymous unix ConnectionSocketFactory into `UnixSocketFactory`
* Makes `LocalDocker(HttpClient, String)` public for users to provide their own HttpClient
* Adds some javadocs