### PR TITLE
(#55) Enabled docker + integration tests in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
+sudo: required
+services:
+  - docker
 language: java
 jdk:
   - oraclejdk8
   - openjdk8
 script:
   - set -e
-  - mvn clean install -Pcheckstyle jacoco:report coveralls:report
+  - mvn clean install -Pcheckstyle,itcases jacoco:report coveralls:report


### PR DESCRIPTION
This PR:
* solves #55 
* Uses as reference the [Travis Docs](https://docs.travis-ci.com/user/docker/)
* enables docker + integration tests in the Travis build

Note: the coverage provided by the integration tests will be included in the coveralls report.