### PR TITLE
(#23) Implemented RemoteDocker

### DIFF
--- a/src/main/java/com/amihaiemil/docker/DefaultHttpClient.java
+++ b/src/main/java/com/amihaiemil/docker/DefaultHttpClient.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2018, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.amihaiemil.docker;
+
+import java.io.IOException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.params.HttpParams;
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * An HttpClient that works over a normal network socket.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @version $Id$
+ * @since 0.0.1
+ * @checkstyle ParameterNumber (150 lines)
+ */
+final class DefaultHttpClient implements HttpClient {
+    /**
+     * Decorated HttpClient.
+     */
+    private final HttpClient origin;
+
+    /**
+     * Ctor.
+     */
+    DefaultHttpClient() {
+        this(
+            HttpClients.custom()
+                .setMaxConnPerRoute(10)
+                .setMaxConnTotal(10)
+                .build()
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param client Decorated HttpClient.
+     */
+    DefaultHttpClient(final HttpClient client) {
+        this.origin = client;
+    }
+  
+    @Override
+    public HttpParams getParams() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+  
+    @Override
+    public ClientConnectionManager getConnectionManager() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+  
+    @Override
+    public HttpResponse execute(final HttpUriRequest request)
+        throws IOException, ClientProtocolException {
+        return this.origin.execute(request);
+    }
+  
+    @Override
+    public HttpResponse execute(final HttpUriRequest request,
+        final HttpContext context)
+        throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+  
+    @Override
+    public HttpResponse execute(final HttpHost target,
+        final HttpRequest request)
+        throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+  
+    @Override
+    public HttpResponse execute(final HttpHost target,
+        final HttpRequest request, final HttpContext context)
+        throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+  
+    @Override
+    public <T> T execute(final HttpUriRequest request,
+        final ResponseHandler<? extends T> responseHandler)
+        throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+  
+    @Override
+    public <T> T execute(final HttpUriRequest request,
+        final ResponseHandler<? extends T> responseHandler,
+        final HttpContext context) throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+  
+    @Override
+    public <T> T execute(final HttpHost target, final HttpRequest request,
+        final ResponseHandler<? extends T> responseHandler)
+        throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+  
+    @Override
+    public <T> T execute(final HttpHost target, final HttpRequest request,
+        final ResponseHandler<? extends T> responseHandler,
+        final HttpContext context) throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+}

--- a/src/main/java/com/amihaiemil/docker/RemoteDocker.java
+++ b/src/main/java/com/amihaiemil/docker/RemoteDocker.java
@@ -25,73 +25,42 @@
  */
 package com.amihaiemil.docker;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import java.io.IOException;
 import java.net.URI;
+import org.apache.http.client.HttpClient;
 
 /**
- * Restful Docker.
- * @author Mihai Andronache (amihaiemil@gmail.com)
+ * Use this to communicate with a remote Docker API.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
  * @version $Id$
  * @since 0.0.1
  */
-abstract class RtDocker implements Docker {
+public final class RemoteDocker extends RtDocker {
+    /**
+     * Remote Docker engine.
+     * @param uri Remote Docker URI.
+     */
+    public RemoteDocker(final URI uri) {
+        this(new DefaultHttpClient(), uri);
+    }
 
     /**
-     * Apache HttpClient which sends the requests.
+     * Remote Docker engine.
+     * @param client The http client to use.
+     * @param uri Remote Docker URI.
      */
-    private final HttpClient client;
+    public RemoteDocker(final HttpClient client, final URI uri) {
+        this(client, uri, "v1.35");
+    }
 
     /**
-     * Base URI.
+     * Remote Docker engine.
+     * @param client The http client to use.
+     * @param uri Remote Docker URI.
+     * @param version API version (eg. v1.35).
      */
-    private final URI baseUri;
-
-    /**
-     * Ctor.
-     * @param client Given HTTP Client.
-     * @param baseUri Base URI.
-     */
-    RtDocker(final HttpClient client, final URI baseUri) {
-        this.client = client;
-        this.baseUri = baseUri;
-    }
-
-    @Override
-    public final boolean ping() throws IOException {
-        final HttpGet ping = new HttpGet(this.baseUri.toString() + "/_ping");
-        final HttpResponse response = this.client.execute(ping);
-        ping.releaseConnection();
-        return response.getStatusLine().getStatusCode() == HttpStatus.SC_OK;
-    }
-
-    @Override
-    public final Containers containers() {
-        return new RtContainers(
-            this.client, URI.create(this.baseUri.toString() + "/containers")
-        );
-    }
-
-    @Override
-    public final Images images() {
-        return null;
-    }
-
-    @Override
-    public final Networks networks() {
-        return null;
-    }
-
-    @Override
-    public final Volumes volumes() {
-        return null;
-    }
-
-    @Override
-    public final Exec exec() {
-        return null;
+    public RemoteDocker(final HttpClient client, final URI uri,
+        final String version) {
+        super(client, uri);
     }
 }

--- a/src/main/java/com/amihaiemil/docker/RemoteDocker.java
+++ b/src/main/java/com/amihaiemil/docker/RemoteDocker.java
@@ -41,7 +41,7 @@ public final class RemoteDocker extends RtDocker {
      * @param uri Remote Docker URI.
      */
     public RemoteDocker(final URI uri) {
-        this(new DefaultHttpClient(), uri);
+        this(new SslHttpClient(), uri);
     }
 
     /**

--- a/src/main/java/com/amihaiemil/docker/SslHttpClient.java
+++ b/src/main/java/com/amihaiemil/docker/SslHttpClient.java
@@ -45,8 +45,11 @@ import org.apache.http.protocol.HttpContext;
  * @version $Id$
  * @since 0.0.1
  * @checkstyle ParameterNumber (150 lines)
+ * @todo #23:30min Add path for certificates as a parameter and, with those
+ *  certificates, register the http/https protocols, similar to how "unix" is
+ *  registered in UnixHttpClient.
  */
-final class DefaultHttpClient implements HttpClient {
+final class SslHttpClient implements HttpClient {
     /**
      * Decorated HttpClient.
      */
@@ -55,7 +58,7 @@ final class DefaultHttpClient implements HttpClient {
     /**
      * Ctor.
      */
-    DefaultHttpClient() {
+    SslHttpClient() {
         this(
             HttpClients.custom()
                 .setMaxConnPerRoute(10)
@@ -68,7 +71,7 @@ final class DefaultHttpClient implements HttpClient {
      * Ctor.
      * @param client Decorated HttpClient.
      */
-    DefaultHttpClient(final HttpClient client) {
+    SslHttpClient(final HttpClient client) {
         this.origin = client;
     }
   

--- a/src/test/java/com/amihaiemil/docker/DefaultHttpClientTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/DefaultHttpClientTestCase.java
@@ -25,73 +25,34 @@
  */
 package com.amihaiemil.docker;
 
-import org.apache.http.HttpResponse;
+import com.amihaiemil.docker.mock.AssertRequest;
+import com.amihaiemil.docker.mock.Response;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import java.io.IOException;
-import java.net.URI;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
 
 /**
- * Restful Docker.
- * @author Mihai Andronache (amihaiemil@gmail.com)
+ * Unit tests for {@link DefaultHttpClient}.
+ * @author George Aristy (george.aristy@gmail.com)
  * @version $Id$
  * @since 0.0.1
+ * @checkstyle MethodName (500 lines)
  */
-abstract class RtDocker implements Docker {
-
+public final class DefaultHttpClientTestCase {
     /**
-     * Apache HttpClient which sends the requests.
+     * DefaultHttpClient can execute the request and return the response.
+     * @throws Exception If an error occurs.
      */
-    private final HttpClient client;
-
-    /**
-     * Base URI.
-     */
-    private final URI baseUri;
-
-    /**
-     * Ctor.
-     * @param client Given HTTP Client.
-     * @param baseUri Base URI.
-     */
-    RtDocker(final HttpClient client, final URI baseUri) {
-        this.client = client;
-        this.baseUri = baseUri;
-    }
-
-    @Override
-    public final boolean ping() throws IOException {
-        final HttpGet ping = new HttpGet(this.baseUri.toString() + "/_ping");
-        final HttpResponse response = this.client.execute(ping);
-        ping.releaseConnection();
-        return response.getStatusLine().getStatusCode() == HttpStatus.SC_OK;
-    }
-
-    @Override
-    public final Containers containers() {
-        return new RtContainers(
-            this.client, URI.create(this.baseUri.toString() + "/containers")
+    @Test
+    public void executesRequestAndReturnsResponse() throws Exception {
+        final Response response = new Response(HttpStatus.SC_OK, "");
+        MatcherAssert.assertThat(
+            new DefaultHttpClient(
+                new AssertRequest(response)
+            ).execute(new HttpGet()),
+            Matchers.is(response)
         );
-    }
-
-    @Override
-    public final Images images() {
-        return null;
-    }
-
-    @Override
-    public final Networks networks() {
-        return null;
-    }
-
-    @Override
-    public final Volumes volumes() {
-        return null;
-    }
-
-    @Override
-    public final Exec exec() {
-        return null;
     }
 }

--- a/src/test/java/com/amihaiemil/docker/DefaultHttpClientTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/DefaultHttpClientTestCase.java
@@ -34,7 +34,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Unit tests for {@link DefaultHttpClient}.
+ * Unit tests for {@link SslHttpClient}.
  * @author George Aristy (george.aristy@gmail.com)
  * @version $Id$
  * @since 0.0.1
@@ -48,8 +48,7 @@ public final class DefaultHttpClientTestCase {
     @Test
     public void executesRequestAndReturnsResponse() throws Exception {
         final Response response = new Response(HttpStatus.SC_OK, "");
-        MatcherAssert.assertThat(
-            new DefaultHttpClient(
+        MatcherAssert.assertThat(new SslHttpClient(
                 new AssertRequest(response)
             ).execute(new HttpGet()),
             Matchers.is(response)

--- a/src/test/java/com/amihaiemil/docker/SslHttpClientTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/SslHttpClientTestCase.java
@@ -40,7 +40,7 @@ import org.junit.Test;
  * @since 0.0.1
  * @checkstyle MethodName (500 lines)
  */
-public final class DefaultHttpClientTestCase {
+public final class SslHttpClientTestCase {
     /**
      * DefaultHttpClient can execute the request and return the response.
      * @throws Exception If an error occurs.
@@ -48,7 +48,8 @@ public final class DefaultHttpClientTestCase {
     @Test
     public void executesRequestAndReturnsResponse() throws Exception {
         final Response response = new Response(HttpStatus.SC_OK, "");
-        MatcherAssert.assertThat(new SslHttpClient(
+        MatcherAssert.assertThat(
+            new SslHttpClient(
                 new AssertRequest(response)
             ).execute(new HttpGet()),
             Matchers.is(response)


### PR DESCRIPTION
This PR:
* solves #23
* Adds `RemoteDocker`
* Adds `SslHttpClient` implementing connection pooling
* Adds some tests for both
* Leaves puzzle to finish testing `RemoteDocker`

Note:
The implementation of `SslHttpClient` is very minimal. I think we can just implement its operations as their need arises. It's also the reason why I added very few tests for it. It's the major reason why coverage decreases with this PR.