### PR TITLE
(#76) Implemented Container.restart()

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Container.java
+++ b/src/main/java/com/amihaiemil/docker/Container.java
@@ -65,4 +65,12 @@ public interface Container {
      *     expected.
      */
     void stop() throws IOException, UnexpectedResponseException;
+
+    /**
+     * Restarts the container.
+     * @throws IOException If something goes wrong.
+     * @throws UnexpectedResponseException If the status response is not
+     *     expected.
+     */
+    void restart() throws IOException, UnexpectedResponseException;
 }

--- a/src/main/java/com/amihaiemil/docker/RtContainer.java
+++ b/src/main/java/com/amihaiemil/docker/RtContainer.java
@@ -39,7 +39,7 @@ import java.net.URI;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
- * @todo #57:30min Keep implementing the rest of the Container operations.
+ * @todo #76:30min Continue implementing the rest of the Container operations.
  *  See the Docker API Docs for reference:
  *  https://docs.docker.com/engine/api/v1.35/#tag/Container
  * @todo #46:30min Once we have the CI environment properly setup with a Docker
@@ -99,6 +99,25 @@ final class RtContainer implements Container {
     public void stop() throws IOException {
         final HttpPost stop = new HttpPost(
             this.baseUri.toString() + "/stop"
+        );
+        try {
+            final int status = this.client.execute(stop)
+                .getStatusLine()
+                .getStatusCode();
+            if (status != HttpStatus.SC_NO_CONTENT) {
+                throw new UnexpectedResponseException(
+                    stop.getURI().toString(), status, HttpStatus.SC_NO_CONTENT
+                );
+            }
+        } finally {
+            stop.releaseConnection();
+        }
+    }
+
+    @Override
+    public void restart() throws IOException, UnexpectedResponseException {
+        final HttpPost stop = new HttpPost(
+            this.baseUri.toString() + "/restart"
         );
         try {
             final int status = this.client.execute(stop)

--- a/src/test/java/com/amihaiemil/docker/RtContainerTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtContainerTestCase.java
@@ -259,4 +259,63 @@ public final class RtContainerTestCase {
             URI.create("http://localhost:80/1.30/containers/123")
         ).stop();
     }
+
+    /**
+     * Wellformed request for the restart command.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void wellformedRestartRequest() throws Exception {
+        new RtContainer(
+            new AssertRequest(
+                new Response(
+                    HttpStatus.SC_NO_CONTENT, ""
+                ),
+                new Condition(
+                    "Method should be a POST",
+                    req -> req.getRequestLine().getMethod().equals("POST")
+                ),
+                new Condition(
+                    "Resource path must be /{id}/restart",
+                    req -> req.getRequestLine()
+                        .getUri().endsWith("/9403/restart")
+                )
+            ),
+            URI.create("http://localhost:80/1.30/containers/9403")
+        ).restart();
+    }
+
+    /**
+     * RtContainer throws UnexpectedResponseException if it receives server
+     * error 500 on restart.
+     * @throws Exception The UnexpectedResponseException.
+     */
+    @Test(expected = UnexpectedResponseException.class)
+    public void restartWithServerError() throws Exception {
+        new RtContainer(
+            new AssertRequest(
+                new Response(
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ""
+                )
+            ),
+            URI.create("http://localhost:80/1.30/containers/123")
+        ).restart();
+    }
+
+    /**
+     * RtContainer throws UnexpectedResponseException if it receives 404 error
+     * on restart.
+     * @throws Exception The UnexpectedResponseException.
+     */
+    @Test(expected = UnexpectedResponseException.class)
+    public void restartsWithNotFound() throws Exception {
+        new RtContainer(
+            new AssertRequest(
+                new Response(
+                    HttpStatus.SC_NOT_FOUND, ""
+                )
+            ),
+            URI.create("http://localhost:80/1.30/containers/123")
+        ).restart();
+    }
 }


### PR DESCRIPTION
This PR:
* solves #76 
* Uses this [documentation](https://docs.docker.com/engine/api/v1.35/#operation/ContainerRestart) as reference
* leaves puzzle for the rest

Note: I'm not sure if it's worth overloading `restart()` with a `timeout` parameter (see the linked docs)