### PR TITLE
#88 Container.kill + unit tests

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Container.java
+++ b/src/main/java/com/amihaiemil/docker/Container.java
@@ -47,7 +47,7 @@ public interface Container {
     JsonObject inspect() throws IOException;
 
     /**
-     * Start a container.
+     * Start this container.
      * @throws IOException If something goes wrong.
      */
     void start() throws IOException;
@@ -59,7 +59,7 @@ public interface Container {
     String containerId();
 
     /**
-     * Stops the container.
+     * Stop this container.
      * @throws IOException If something goes wrong.
      * @throws UnexpectedResponseException If the status response is not
      *     expected.
@@ -67,7 +67,15 @@ public interface Container {
     void stop() throws IOException, UnexpectedResponseException;
 
     /**
-     * Restarts the container.
+     * Kill this container. SIGKILL is sent to this container.
+     * @throws IOException If something goes wrong.
+     * @throws UnexpectedResponseException If the status response is not
+     *     expected.
+     */
+    void kill() throws IOException, UnexpectedResponseException;
+
+    /**
+     * Restarts this container.
      * @throws IOException If something goes wrong.
      * @throws UnexpectedResponseException If the status response is not
      *     expected.

--- a/src/main/java/com/amihaiemil/docker/RtContainer.java
+++ b/src/main/java/com/amihaiemil/docker/RtContainer.java
@@ -39,8 +39,8 @@ import java.net.URI;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
- * @todo #76:30min Continue implementing the rest of the Container operations.
- *  See the Docker API Docs for reference:
+ * @todo #88:30min Continue implementing the rest of the Container operations
+ *  (pause, unpause, rename, logs etc) See the Docker API Docs for reference:
  *  https://docs.docker.com/engine/api/v1.35/#tag/Container
  * @todo #46:30min Once we have the CI environment properly setup with a Docker
  *  instance, write integration tests for this class as well
@@ -111,6 +111,25 @@ final class RtContainer implements Container {
             }
         } finally {
             stop.releaseConnection();
+        }
+    }
+
+    @Override
+    public void kill() throws IOException, UnexpectedResponseException {
+        final HttpPost kill = new HttpPost(
+            this.baseUri.toString() + "/kill"
+        );
+        try {
+            final int status = this.client.execute(kill)
+                .getStatusLine()
+                .getStatusCode();
+            if (status != HttpStatus.SC_NO_CONTENT) {
+                throw new UnexpectedResponseException(
+                    kill.getURI().toString(), status, HttpStatus.SC_NO_CONTENT
+                );
+            }
+        } finally {
+            kill.releaseConnection();
         }
     }
 

--- a/src/test/java/com/amihaiemil/docker/RtContainerTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtContainerTestCase.java
@@ -102,7 +102,7 @@ public final class RtContainerTestCase {
     }
 
     /**
-     * RtContainer.inspect() throws ISE because the HTTP Response's status
+     * RtContainer.inspect() throws URE because the HTTP Response's status
      * is not 200 OK.
      * @throws Exception If something goes wrong.
      */
@@ -141,7 +141,7 @@ public final class RtContainerTestCase {
     }
 
     /**
-     * RtContainer throws ISE if it receives server error on start.
+     * RtContainer throws URE if it receives server error on start.
      * @throws Exception If something goes wrong.
      */
     @Test(expected = UnexpectedResponseException.class)
@@ -157,7 +157,7 @@ public final class RtContainerTestCase {
     }
 
     /**
-     * RtContainer throws ISE if it receives "Not Found" on start.
+     * RtContainer throws URE if it receives "Not Found" on start.
      * @throws Exception If something goes wrong.
      */
     @Test(expected = UnexpectedResponseException.class)
@@ -173,7 +173,7 @@ public final class RtContainerTestCase {
     }
 
     /**
-     * RtContainer throws ISE if it receives "Not Modified" on start.
+     * RtContainer throws URE if it receives "Not Modified" on start.
      * @throws Exception If something goes wrong.
      */
     @Test(expected = UnexpectedResponseException.class)
@@ -213,7 +213,7 @@ public final class RtContainerTestCase {
     }
 
     /**
-     * RtContainer throws ISE if it receives server error on stop.
+     * RtContainer throws URE if it receives server error on stop.
      * @throws Exception If something goes wrong.
      */
     @Test(expected = UnexpectedResponseException.class)
@@ -229,7 +229,7 @@ public final class RtContainerTestCase {
     }
 
     /**
-     * RtContainer throws ISE if it receives "Not Found" on stop.
+     * RtContainer throws URE if it receives "Not Found" on stop.
      * @throws Exception If something goes wrong.
      */
     @Test(expected = UnexpectedResponseException.class)
@@ -245,7 +245,7 @@ public final class RtContainerTestCase {
     }
 
     /**
-     * RtContainer throws ISE if it receives "Not Modified" on stop.
+     * RtContainer throws URE if it receives "Not Modified" on stop.
      * @throws Exception If something goes wrong.
      */
     @Test(expected = UnexpectedResponseException.class)
@@ -317,5 +317,61 @@ public final class RtContainerTestCase {
             ),
             URI.create("http://localhost:80/1.30/containers/123")
         ).restart();
+    }
+
+    /**
+     * RtContainer can be killed with no problem.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void killedOk() throws Exception {
+        new RtContainer(
+            new AssertRequest(
+                new Response(
+                    HttpStatus.SC_NO_CONTENT, ""
+                ),
+                new Condition(
+                    "Method should be a POST",
+                    req -> req.getRequestLine().getMethod().equals("POST")
+                ),
+                new Condition(
+                    "Resource path must be /{id}/kill",
+                    req -> req.getRequestLine().getUri().endsWith("/123/kill")
+                )
+            ),
+            URI.create("http://localhost:80/1.30/containers/123")
+        ).kill();
+    }
+
+    /**
+     * RtContainer throws URE if it receives server error on kill.
+     * @throws Exception If something goes wrong.
+     */
+    @Test(expected = UnexpectedResponseException.class)
+    public void killedWithServerError() throws Exception {
+        new RtContainer(
+            new AssertRequest(
+                new Response(
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ""
+                )
+            ),
+            URI.create("http://localhost:80/1.30/containers/123")
+        ).kill();
+    }
+
+    /**
+     * RtContainer throws URE if it receives "Not Found" on kill.
+     * @throws Exception If something goes wrong.
+     */
+    @Test(expected = UnexpectedResponseException.class)
+    public void killedWithNotFound() throws Exception {
+        new RtContainer(
+            new AssertRequest(
+                new Response(
+                    HttpStatus.SC_NOT_FOUND, ""
+                )
+            ),
+            URI.create("http://localhost:80/1.30/containers/123")
+        ).kill();
     }
 }


### PR DESCRIPTION
PR for #88 
Implemented and unit tested Container#kill. Left todo for the rest.

**Note:** We are starting to have quite some code duplication inside ``restart()``, ``stop()`` and ``kill()``. Any suggestion on how we could get rid of it elegantly?