### PR TITLE
#86 Image.inspect, Image.history + unit tests

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Image.java
+++ b/src/main/java/com/amihaiemil/docker/Image.java
@@ -50,7 +50,7 @@ public interface Image {
     JsonObject inspect() throws IOException, UnexpectedResponseException;
     
     /**
-     * Return parent layers of an Image.
+     * Return parent layers of this Image.
      * @return Images parent Images.
      * @see <a href="https://docs.docker.com/engine/api/v1.35/#operation/ImageHistory">Image History</a>
      */

--- a/src/main/java/com/amihaiemil/docker/Image.java
+++ b/src/main/java/com/amihaiemil/docker/Image.java
@@ -25,15 +25,35 @@
  */
 package com.amihaiemil.docker;
 
+import java.io.IOException;
+import javax.json.JsonObject;
+
 /**
  * A docker image.
  * @author George Aristy (george.aristy@gmail.com)
  * @version $Id$
  * @see <a href="https://docs.docker.com/engine/api/v1.35/#tag/Image">Docker Images API</a>
  * @since 0.0.1
- * @todo #71:30min Implement the operations that affect a single docker image,
- *  see the link referenced above.
+ * @todo #86:30min Continue implementing the operations that affect a single
+ *  docker image. See the link referenced above.
  */
 public interface Image {
 
+    /**
+     * Return low-level information about this image. 
+     * @return JsonObject information.
+     * @see <a href="https://docs.docker.com/engine/api/v1.35/#operation/ImageInspect">Inspect Image</a>
+     * @throws IOException If something goes wrong.
+     * @throws UnexpectedResponseException If the status response is not
+     *  the expected one (200 OK).
+     */
+    JsonObject inspect() throws IOException, UnexpectedResponseException;
+    
+    /**
+     * Return parent layers of an Image.
+     * @return Images parent Images.
+     * @see <a href="https://docs.docker.com/engine/api/v1.35/#operation/ImageHistory">Image History</a>
+     */
+    Images history();
+    
 }

--- a/src/main/java/com/amihaiemil/docker/RtImage.java
+++ b/src/main/java/com/amihaiemil/docker/RtImage.java
@@ -25,7 +25,9 @@
  */
 package com.amihaiemil.docker;
 
+import java.io.IOException;
 import java.net.URI;
+import javax.json.JsonObject;
 import org.apache.http.client.HttpClient;
 
 /**
@@ -46,19 +48,25 @@ final class RtImage implements Image {
     private final URI baseUri;
 
     /**
-     * This image's id.
-     */
-    private final String id;
-
-    /**
      * Ctor.
      * @param client The http client.
      * @param uri The URI for this image.
-     * @param id This image's id.
      */
-    RtImage(final HttpClient client, final URI uri, final String id) {
+    RtImage(final HttpClient client, final URI uri) {
         this.client = client;
         this.baseUri = uri;
-        this.id = id;
+    }
+
+    @Override
+    public JsonObject inspect()
+        throws IOException, UnexpectedResponseException {
+        return new Inspection(this.client, this.baseUri.toString() + "/json");
+    }
+
+    @Override
+    public Images history() {
+        return new RtImages(
+            this.client, URI.create(this.baseUri.toString() + "/history")
+        );
     }
 }

--- a/src/main/java/com/amihaiemil/docker/RtImages.java
+++ b/src/main/java/com/amihaiemil/docker/RtImages.java
@@ -81,7 +81,10 @@ final class RtImages implements Images {
                 .stream()
                 .map(json -> (JsonObject) json)
                 .map(json -> new RtImage(
-                    this.client, this.baseUri, json.getString("Id")
+                    this.client,
+                    URI.create(
+                        this.baseUri.toString() + "/" + json.getString("Id")
+                    )
                 )).collect(Collectors.toList());
         } finally {
             get.releaseConnection();

--- a/src/test/java/com/amihaiemil/docker/RtImageTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImageTestCase.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2018, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.amihaiemil.docker;
+
+import com.amihaiemil.docker.mock.AssertRequest;
+import com.amihaiemil.docker.mock.Condition;
+import com.amihaiemil.docker.mock.Response;
+import java.net.URI;
+import javax.json.Json;
+import javax.json.JsonObject;
+import org.apache.http.HttpStatus;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Unit tests for RtImage.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.1
+ */
+public final class RtImageTestCase {
+
+    /**
+     * RtImage can return info about itself.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void inspectsItself() throws Exception {
+        final Image image = new RtImage(
+            new AssertRequest(
+                new Response(
+                    HttpStatus.SC_OK,
+                    Json.createObjectBuilder()
+                        .add("Id", "456")
+                        .add("Container", "cb91e48a60d01f1e27028b4")
+                        .add("Commant", "bla bla")
+                        .add("Os", "linux")
+                        .build().toString()
+                ),
+                new Condition(
+                    "Method should be a GET",
+                    req -> req.getRequestLine().getMethod().equals("GET")
+                ),
+                new Condition(
+                    "Resource path must be /{id}/json",
+                    req -> req.getRequestLine().getUri().endsWith("/456/json")
+                )
+            ),
+            URI.create("http://localhost:80/1.30/images/456")
+        );
+        final JsonObject info = image.inspect();
+        MatcherAssert.assertThat(info.keySet(), Matchers.hasSize(4));
+        MatcherAssert.assertThat(
+            info.getString("Id"), Matchers.equalTo("456")
+        );
+        MatcherAssert.assertThat(
+            info.getString("Container"),
+            Matchers.equalTo("cb91e48a60d01f1e27028b4")
+        );
+        MatcherAssert.assertThat(
+            info.getString("Commant"), Matchers.equalTo("bla bla")
+        );
+        MatcherAssert.assertThat(
+            info.getString("Os"), Matchers.equalTo("linux")
+        );
+    }
+    
+    /**
+     * RtImage can return its history Images.
+     */
+    @Test
+    public void returnsHistory() {
+        MatcherAssert.assertThat(
+            new RtImage(
+                new AssertRequest(
+                    new Response(
+                        HttpStatus.SC_OK,
+                        Json.createArrayBuilder().build().toString()
+                    )
+                ),
+                URI.create("http://localhost:80/1.30/images/456")
+            ).history(),
+            Matchers.allOf(
+                Matchers.notNullValue(),
+                Matchers.instanceOf(Images.class)
+            )
+        );
+    }
+}


### PR DESCRIPTION
PR for #86 

Implemented and unit tested the 2 methods. What is interesting is that ``Image.history`` returns an instance of ``Images``, since that's what they are: previous layers (versions) which constituted ``this Image`` over time.

We will have to make a better design in ``RtImages.iterate`` since now we don't always have to append ``/json`` when iterationg.