### PR TITLE
(#83) Implemented Images.create()

### DIFF
--- a/src/main/java/com/amihaiemil/docker/RtImages.java
+++ b/src/main/java/com/amihaiemil/docker/RtImages.java
@@ -27,6 +27,7 @@ package com.amihaiemil.docker;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URL;
 import java.util.stream.Collectors;
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -34,6 +35,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
 
 /**
  * Runtime {@link Images}.
@@ -85,6 +87,39 @@ final class RtImages implements Images {
                 )).collect(Collectors.toList());
         } finally {
             get.releaseConnection();
+        }
+    }
+
+    // @todo #83:30min Several API calls required an authentication header as
+    //  explained here:
+    //  https://docs.docker.com/engine/api/v1.35/#section/Authentication
+    //  (including Images.create()). Find a way to make a reusable object from
+    //  that action and introduce it here.
+    // @checkstyle ParameterNumber (4 lines)
+    @Override
+    public Images create(
+        final String name, final URL source, final String repo, final String tag
+    ) throws IOException, UnexpectedResponseException {
+        final HttpPost create  = new HttpPost(
+            new UncheckedUriBuilder(this.baseUri.toString().concat("/create"))
+                .addParameter("fromImage", name)
+                .addParameter("fromSrc", source.toString())
+                .addParameter("repo", repo)
+                .addParameter("tag", tag)
+                .build()
+        );
+        try {
+            final int status = this.client.execute(create)
+                .getStatusLine()
+                .getStatusCode();
+            if (HttpStatus.SC_OK != status) {
+                throw new UnexpectedResponseException(
+                    create.getURI().toString(), status, HttpStatus.SC_OK
+                );
+            }
+            return this;
+        } finally {
+            create.releaseConnection();
         }
     }
 }

--- a/src/main/java/com/amihaiemil/docker/UncheckedUriBuilder.java
+++ b/src/main/java/com/amihaiemil/docker/UncheckedUriBuilder.java
@@ -25,44 +25,45 @@
  */
 package com.amihaiemil.docker;
 
-import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.apache.http.client.utils.URIBuilder;
 
 /**
- * Images API.
- * @author Mihai Andronache (amihaiemil@gmail.com)
- * @version $Id$
- * @see <a href="https://docs.docker.com/engine/api/v1.35/#tag/Image">Docker Images API</a>
- * @since 0.0.1
- * @todo #83:30min Keep implementing the rest of the operations for the
- *  Images interface. See the docs referenced above for more details.
+ * A {@link URIBuilder} that hides checked exceptions in the methods used
+ * throughout this library. Used under the assumption that the structure
+ * of URIs created using this class are valid.
+ * @author George Aristy (george.aristy@gmail.com)
  */
-public interface Images {
+final class UncheckedUriBuilder extends URIBuilder {
     /**
-     * All images on the docker server.
-     * @return The images.
-     * @throws IOException If an I/O error occurs.
-     * @throws UnexpectedResponseException If the API responds with an 
-     *  unexpected status.
-     * @todo #71:30min Images should extend Iterable<Image>. Refactor so that
-     *  the user should not have to call this `iterate()` method and instead
-     *  just iterate on 'docker.images()'.
+     * Ctor.
+     * @param uri Base URI.
+     * @throws IllegalArgumentException From {@link URI#create(String)}.
+     * @throws NullPointerException From {@link URI#create(String)}.
      */
-    Iterable<Image> iterate() throws IOException, UnexpectedResponseException;
+    UncheckedUriBuilder(
+        final String uri
+    ) throws IllegalArgumentException, NullPointerException {
+        super(URI.create(uri));
+    }
 
-    /**
-     * Creates an image by pulling it from a registry.
-     * @param name Name of the image to pull.
-     * @param source The URL from which the image can be retrieved.
-     * @param repo Repository name for the image when it is pulled.
-     * @param tag Tag or digest for the image.
-     * @return This {@link Images}.
-     * @throws IOException If an I/O error occurs.
-     * @throws UnexpectedResponseException If the API responds with an 
-     *  unexpected status.
-     * @checkstyle ParameterNumber (4 lines)
-     */
-    Images create(
-        final String name, final URL source, final String repo, final String tag
-    ) throws IOException, UnexpectedResponseException;
+    @Override
+    public UncheckedUriBuilder addParameter(
+        final String name, final String value
+    ) {
+        super.addParameter(name, value);
+        return this;
+    }
+
+    @Override
+    public URI build() {
+        try {
+            return super.build();
+        } catch (final URISyntaxException ex) {
+            throw new IllegalStateException(
+                "Unexpected error while building a URI!", ex
+            );
+        }
+    }
 }

--- a/src/main/java/com/amihaiemil/docker/UncheckedUriBuilder.java
+++ b/src/main/java/com/amihaiemil/docker/UncheckedUriBuilder.java
@@ -34,6 +34,8 @@ import org.apache.http.client.utils.URIBuilder;
  * throughout this library. Used under the assumption that the structure
  * of URIs created using this class are valid.
  * @author George Aristy (george.aristy@gmail.com)
+ * @version $Id$
+ * @since 0.0.1
  */
 final class UncheckedUriBuilder extends URIBuilder {
     /**

--- a/src/test/java/com/amihaiemil/docker/mock/Response.java
+++ b/src/test/java/com/amihaiemil/docker/mock/Response.java
@@ -67,6 +67,16 @@ public final class Response implements HttpResponse {
 
     /**
      * Ctor.
+     * <p>
+     * Response with no payload.
+     * @param status The {@link HttpStatus http status code}
+     */
+    public Response(final int status) {
+        this(status, "");
+    }
+
+    /**
+     * Ctor.
      *
      * @param status The {@link HttpStatus http status code}
      * @param jsonPayload The json payload


### PR DESCRIPTION
This PR:
* Solves #83
* Uses the [ImageCreate](https://docs.docker.com/engine/api/v1.35/#operation/ImageCreate) docs as reference
* Adds helper class `UncheckedUriBuilder`
* Adds new ctor to `Response` for responses w/o payload
* Leaves puzzle to implement reusable [Authentication](https://docs.docker.com/engine/api/v1.35/#section/Authentication)
* Leaves puzzle for the rest of the `Images` operations