### PR TITLE
(#103) Implemented Image.tag()

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Image.java
+++ b/src/main/java/com/amihaiemil/docker/Image.java
@@ -34,9 +34,6 @@ import javax.json.JsonObject;
  * @version $Id$
  * @see <a href="https://docs.docker.com/engine/api/v1.35/#tag/Image">Docker Images API</a>
  * @since 0.0.1
- * @todo #96:30min Finish implementing the operations that affect a single
- *  docker image (I think `tag` is the only one remaining). See the link
- *  referenced above.
  */
 public interface Image {
 
@@ -58,11 +55,25 @@ public interface Image {
     Images history();
 
     /**
-     * The parent {@link Images}.
+     * Remove an image, along with any untagged parent images that were
+     * referenced by that image.
      * @throws IOException If something goes wrong.
      * @throws UnexpectedResponseException If the status response is not
      *  the expected one (200 OK).
      * @see <a href="https://docs.docker.com/engine/api/v1.35/#operation/ImageDelete">Remove an image</a>
      */
     void delete() throws IOException, UnexpectedResponseException;
+
+    /**
+     * Tags this image so that it becomes part of a repository.
+     * @param repo The repository to tag in. Eg.: "someuser/someimage"
+     * @param name The name of the new tag.
+     * @throws IOException If something goes wrong.
+     * @throws UnexpectedResponseException If the status response is not
+     *  the expected one.
+     * @see <a href="https://docs.docker.com/engine/api/v1.35/#operation/ImageTag">Tag an image</a>
+     */
+    void tag(
+        String repo, String name
+    ) throws IOException, UnexpectedResponseException;
 }

--- a/src/main/java/com/amihaiemil/docker/RtImage.java
+++ b/src/main/java/com/amihaiemil/docker/RtImage.java
@@ -31,6 +31,7 @@ import javax.json.JsonObject;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpPost;
 
 /**
  * Runtime {@link Image}.
@@ -86,6 +87,27 @@ final class RtImage implements Image {
             }
         } finally {
             delete.releaseConnection();
+        }
+    }
+
+    @Override
+    public void tag(
+        final String repo, final String name
+    ) throws IOException, UnexpectedResponseException {
+        final HttpPost tag = new HttpPost(
+            new UncheckedUriBuilder(
+                this.baseUri.toString() + "/tag"
+            ).addParameter("repo", repo)
+            .addParameter("tag", name)
+            .build()
+        );
+        try {
+            this.client.execute(
+                tag,
+                new MatchStatus(tag.getURI(), HttpStatus.SC_CREATED)
+            );
+        } finally {
+            tag.releaseConnection();
         }
     }
 }

--- a/src/test/java/com/amihaiemil/docker/RtImageTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImageTestCase.java
@@ -180,4 +180,90 @@ public final class RtImageTestCase {
             URI.create("http://localhost/images/test")
         ).delete();
     }
+
+    /**
+     * RtImage.tag() must send a POST request to the image's URL.
+     * 
+     * Note the escaped forward slash in the query parameters.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void tagsOk() throws Exception {
+        new RtImage(
+            new AssertRequest(
+                new Response(HttpStatus.SC_CREATED),
+                new Condition(
+                    "RtImage.tag() must send a POST request",
+                    req -> "POST".equals(req.getRequestLine().getMethod())
+                ),
+                new Condition(
+                    "RtImage.tag() not building the URL correctly",
+                    req -> req.getRequestLine().getUri().endsWith(
+                        "/images/123/tag?repo=myrepo%2Fmyimage&tag=mytag"
+                    )
+                )
+            ),
+            URI.create("http://localhost/images/123")
+        ).tag("myrepo/myimage", "mytag");
+    }
+
+    /**
+     * RtImage.tag() must throw UnexpectedResponseException if docker responds
+     * with 400.
+     * @throws Exception The UnexpectedResponseException.
+     */
+    @Test(expected = UnexpectedResponseException.class)
+    public void tagErrorIfResponseIs400() throws Exception {
+        new RtImage(
+            new AssertRequest(
+                new Response(HttpStatus.SC_BAD_REQUEST)
+            ),
+            URI.create("https://localhost")
+        ).tag("myrepo/myimage", "mytag");
+    }
+
+    /**
+     * RtImage.tag() must throw UnexpectedResponseException if docker responds
+     * with 404.
+     * @throws Exception The UnexpectedResponseException.
+     */
+    @Test(expected = UnexpectedResponseException.class)
+    public void tagErrorIfResponseIs404() throws Exception {
+        new RtImage(
+            new AssertRequest(
+                new Response(HttpStatus.SC_NOT_FOUND)
+            ),
+            URI.create("https://localhost")
+        ).tag("myrepo/myimage", "mytag");
+    }
+
+    /**
+     * RtImage.tag() must throw UnexpectedResponseException if docker responds
+     * with 409.
+     * @throws Exception The UnexpectedResponseException.
+     */
+    @Test(expected = UnexpectedResponseException.class)
+    public void tagErrorIfResponseIs409() throws Exception {
+        new RtImage(
+            new AssertRequest(
+                new Response(HttpStatus.SC_CONFLICT)
+            ),
+            URI.create("https://localhost")
+        ).tag("myrepo/myimage", "mytag");
+    }
+
+    /**
+     * RtImage.tag() must throw UnexpectedResponseException if docker responds
+     * with 500.
+     * @throws Exception The UnexpectedResponseException.
+     */
+    @Test(expected = UnexpectedResponseException.class)
+    public void tagErrorIfResponseIs500() throws Exception {
+        new RtImage(
+            new AssertRequest(
+                new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+            ),
+            URI.create("https://localhost")
+        ).tag("myrepo/myimage", "mytag");
+    }
 }


### PR DESCRIPTION
This PR:
* solves #103 
* uses the [ImageTag Docs](https://docs.docker.com/engine/api/v1.35/#operation/ImageTag) as reference
* Implements `Image.tag()`