### PR TITLE
JsonObject polymorphism and avoid n+1 query

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Container.java
+++ b/src/main/java/com/amihaiemil/docker/Container.java
@@ -34,7 +34,7 @@ import java.io.IOException;
  * @version $Id$
  * @since 0.0.1
  */
-public interface Container {
+public interface Container extends JsonObject {
 
     /**
      * Inspect this container, return low-level information

--- a/src/main/java/com/amihaiemil/docker/Inspection.java
+++ b/src/main/java/com/amihaiemil/docker/Inspection.java
@@ -26,15 +26,8 @@
 package com.amihaiemil.docker;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
 import javax.json.Json;
-import javax.json.JsonArray;
-import javax.json.JsonNumber;
 import javax.json.JsonObject;
-import javax.json.JsonString;
-import javax.json.JsonValue;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
@@ -46,11 +39,7 @@ import org.apache.http.client.methods.HttpGet;
  * @version $Id$
  * @since 0.0.1
  */
-final class Inspection implements JsonObject {
-    /**
-     * Enclosed json object.
-     */
-    private final JsonObject json;
+final class Inspection extends JsonResource {
 
     /**
      * Ctor.
@@ -61,12 +50,25 @@ final class Inspection implements JsonObject {
      */
     Inspection(final HttpClient client, final String url)
         throws UnexpectedResponseException, IOException {
+        super(fetch(client, url));
+    }
+    
+    /**
+     * Fetch the JsonObject resource.
+     * @param client The Http client.
+     * @param url The request URL.
+     * @return The fetched JsonObject.
+     * @throws UnexpectedResponseException If Docker's response code is not 200.
+     * @throws IOException If an I/O error occurs.
+     */
+    private static JsonObject fetch(final HttpClient client, final String url)
+        throws UnexpectedResponseException, IOException {
         final HttpGet inspect = new HttpGet(url);
         try {
             final HttpResponse response = client.execute(inspect);
             final int status = response.getStatusLine().getStatusCode();
             if (status == HttpStatus.SC_OK) {
-                this.json = Json
+                return Json
                     .createReader(response.getEntity().getContent())
                     .readObject();
             } else {
@@ -77,130 +79,5 @@ final class Inspection implements JsonObject {
         } finally {
             inspect.releaseConnection();
         }
-    }
-
-    @Override
-    public JsonArray getJsonArray(final String name) {
-        return this.json.getJsonArray(name);
-    }
-
-    @Override
-    public JsonObject getJsonObject(final String name) {
-        return this.json.getJsonObject(name);
-    }
-
-    @Override
-    public JsonNumber getJsonNumber(final String name) {
-        return this.json.getJsonNumber(name);
-    }
-
-    @Override
-    public JsonString getJsonString(final String name) {
-        return this.json.getJsonString(name);
-    }
-
-    @Override
-    public String getString(final String name) {
-        return this.json.getString(name);
-    }
-
-    @Override
-    public String getString(final String name, final String defaultValue) {
-        return this.json.getString(name, defaultValue);
-    }
-
-    @Override
-    public int getInt(final String name) {
-        return this.json.getInt(name);
-    }
-
-    @Override
-    public int getInt(final String name, final int defaultValue) {
-        return this.json.getInt(name, defaultValue);
-    }
-
-    @Override
-    public boolean getBoolean(final String name) {
-        return this.json.getBoolean(name);
-    }
-
-    @Override
-    public boolean getBoolean(final String name, final boolean defaultValue) {
-        return this.json.getBoolean(name, defaultValue);
-    }
-
-    @Override
-    public boolean isNull(final String name) {
-        return this.json.isNull(name);
-    }
-
-    @Override
-    public ValueType getValueType() {
-        return this.json.getValueType();
-    }
-
-    @Override
-    public int size() {
-        return this.json.size();
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return this.json.isEmpty();
-    }
-
-    @Override
-    public boolean containsKey(final Object key) {
-        return this.json.containsKey(key);
-    }
-
-    @Override
-    public boolean containsValue(final Object value) {
-        return this.json.containsValue(value);
-    }
-
-    @Override
-    public JsonValue get(final Object key) {
-        return this.json.get(key);
-    }
-
-    @Override
-    public JsonValue put(final String key, final JsonValue value) {
-        return this.json.put(key, value);
-    }
-
-    @Override
-    public JsonValue remove(final Object key) {
-        return this.json.remove(key);
-    }
-
-    @Override
-    public void putAll(final Map<? extends String, ? extends JsonValue> map) {
-        this.json.putAll(map);
-    }
-
-    @Override
-    public void clear() {
-        this.json.clear();
-    }
-
-    @Override
-    public Set<String> keySet() {
-        return this.json.keySet();
-    }
-
-    @Override
-    public Collection<JsonValue> values() {
-        return this.json.values();
-    }
-
-    @Override
-    public Set<Entry<String, JsonValue>> entrySet() {
-        return this.json.entrySet();
-    }
-
-    @Override
-    public String toString() {
-        return this.json.toString();
     }
 }

--- a/src/main/java/com/amihaiemil/docker/JsonResource.java
+++ b/src/main/java/com/amihaiemil/docker/JsonResource.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2018, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.amihaiemil.docker;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import javax.json.JsonArray;
+import javax.json.JsonNumber;
+import javax.json.JsonObject;
+import javax.json.JsonString;
+import javax.json.JsonValue;
+
+/**
+ * A JsonObject resource returned by the API (could be a Container,
+ * an Image etc).
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.1
+ * @todo #114:30min Continue making other Json resources from
+ *  the API (e.g. Image), extend this class, so we can avoid the N+1
+ *  query problem. Through this mechanism, each resource holds the JsonObject
+ *  that was returned by the API at the moment of its creation. If the client
+ *  would like to make sure that the resource's JsonObject is updated, they
+ *  should call the inspect() method.
+ */
+abstract class JsonResource implements JsonObject {
+    
+    /**
+     * The JsonObject resource in question.
+     */
+    private final JsonObject resource;
+    
+    /**
+     * Ctor.
+     * @param resource The JsonObject resource in question.
+     */
+    JsonResource(final JsonObject resource) {
+        this.resource = resource;
+    }
+    
+    @Override
+    public JsonArray getJsonArray(final String name) {
+        return this.resource.getJsonArray(name);
+    }
+
+    @Override
+    public JsonObject getJsonObject(final String name) {
+        return this.resource.getJsonObject(name);
+    }
+
+    @Override
+    public JsonNumber getJsonNumber(final String name) {
+        return this.resource.getJsonNumber(name);
+    }
+
+    @Override
+    public JsonString getJsonString(final String name) {
+        return this.resource.getJsonString(name);
+    }
+
+    @Override
+    public String getString(final String name) {
+        return this.resource.getString(name);
+    }
+
+    @Override
+    public String getString(final String name, final String defaultValue) {
+        return this.resource.getString(name, defaultValue);
+    }
+
+    @Override
+    public int getInt(final String name) {
+        return this.resource.getInt(name);
+    }
+
+    @Override
+    public int getInt(final String name, final int defaultValue) {
+        return this.resource.getInt(name, defaultValue);
+    }
+
+    @Override
+    public boolean getBoolean(final String name) {
+        return this.resource.getBoolean(name);
+    }
+
+    @Override
+    public boolean getBoolean(final String name, final boolean defaultValue) {
+        return this.resource.getBoolean(name, defaultValue);
+    }
+
+    @Override
+    public boolean isNull(final String name) {
+        return this.resource.isNull(name);
+    }
+
+    @Override
+    public ValueType getValueType() {
+        return this.resource.getValueType();
+    }
+
+    @Override
+    public int size() {
+        return this.resource.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.resource.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(final Object key) {
+        return this.resource.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(final Object value) {
+        return this.resource.containsValue(value);
+    }
+
+    @Override
+    public JsonValue get(final Object key) {
+        return this.resource.get(key);
+    }
+
+    @Override
+    public JsonValue put(final String key, final JsonValue value) {
+        return this.resource.put(key, value);
+    }
+
+    @Override
+    public JsonValue remove(final Object key) {
+        return this.resource.remove(key);
+    }
+
+    @Override
+    public void putAll(final Map<? extends String, ? extends JsonValue> map) {
+        this.resource.putAll(map);
+    }
+
+    @Override
+    public void clear() {
+        this.resource.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return this.resource.keySet();
+    }
+
+    @Override
+    public Collection<JsonValue> values() {
+        return this.resource.values();
+    }
+
+    @Override
+    public Set<Entry<String, JsonValue>> entrySet() {
+        return this.resource.entrySet();
+    }
+
+    @Override
+    public String toString() {
+        return this.resource.toString();
+    }
+}

--- a/src/main/java/com/amihaiemil/docker/RtContainer.java
+++ b/src/main/java/com/amihaiemil/docker/RtContainer.java
@@ -46,7 +46,7 @@ import java.net.URI;
  *  a Docker instance, continue integration tests for RtContainer(s) and other
  *  parts of the API.
  */
-final class RtContainer implements Container {
+final class RtContainer extends JsonResource implements Container {
 
     /**
      * Apache HttpClient which sends the requests.
@@ -60,10 +60,14 @@ final class RtContainer implements Container {
 
     /**
      * Ctor.
+     * @param rep JsonObject representation of this Container.
      * @param client Given HTTP Client.
      * @param baseUri Base URI, ending with /{containerId}.
      */
-    RtContainer(final HttpClient client, final URI baseUri) {
+    RtContainer(
+        final JsonObject rep, final HttpClient client, final URI baseUri
+    ) {
+        super(rep);
         this.client = client;
         this.baseUri = baseUri;
     }
@@ -90,9 +94,7 @@ final class RtContainer implements Container {
 
     @Override
     public String containerId() {
-        return this.baseUri.toString().substring(
-            this.baseUri.toString().lastIndexOf("/") + 1
-        );
+        return this.getString("Id");
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/docker/RtContainers.java
+++ b/src/main/java/com/amihaiemil/docker/RtContainers.java
@@ -111,6 +111,7 @@ final class RtContainers implements Containers {
                 .createReader(response.getEntity().getContent()).readObject();
             post.releaseConnection();
             return new RtContainer(
+                json,
                 this.client,
                 URI.create(
                     this.baseUri.toString() + "/" + json.getString("Id")

--- a/src/test/java/com/amihaiemil/docker/RtContainerTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtContainerTestCase.java
@@ -52,6 +52,7 @@ public final class RtContainerTestCase {
     @Test
     public void returnsId() {
         final Container container = new RtContainer(
+            Json.createObjectBuilder().add("Id", "123id456").build(),
             Mockito.mock(HttpClient.class),
             URI.create("unix://localhost:80/1.30/containers/123id456")
         );
@@ -68,6 +69,7 @@ public final class RtContainerTestCase {
     @Test
     public void inspectsItself() throws Exception {
         final Container container = new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_OK,
@@ -109,6 +111,7 @@ public final class RtContainerTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void inspectsNotFound() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(HttpStatus.SC_NOT_FOUND, "")
             ),
@@ -123,6 +126,7 @@ public final class RtContainerTestCase {
     @Test
     public void startsOk() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_NO_CONTENT, ""
@@ -147,6 +151,7 @@ public final class RtContainerTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void startsWithServerError() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, ""
@@ -163,6 +168,7 @@ public final class RtContainerTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void startsWithNotFound() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_NOT_FOUND, ""
@@ -179,6 +185,7 @@ public final class RtContainerTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void startsWithNotModified() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_NOT_MODIFIED, ""
@@ -195,6 +202,7 @@ public final class RtContainerTestCase {
     @Test
     public void stopsOk() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_NO_CONTENT, ""
@@ -219,6 +227,7 @@ public final class RtContainerTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void stopsWithServerError() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, ""
@@ -235,6 +244,7 @@ public final class RtContainerTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void stopsWithNotFound() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_NOT_FOUND, ""
@@ -251,6 +261,7 @@ public final class RtContainerTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void stopsWithNotModified() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_NOT_MODIFIED, ""
@@ -267,6 +278,7 @@ public final class RtContainerTestCase {
     @Test
     public void wellformedRestartRequest() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "9403").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_NO_CONTENT, ""
@@ -293,6 +305,7 @@ public final class RtContainerTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void restartWithServerError() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, ""
@@ -310,6 +323,7 @@ public final class RtContainerTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void restartsWithNotFound() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_NOT_FOUND, ""
@@ -326,6 +340,7 @@ public final class RtContainerTestCase {
     @Test
     public void killedOk() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_NO_CONTENT, ""
@@ -350,6 +365,7 @@ public final class RtContainerTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void killedWithServerError() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, ""
@@ -366,6 +382,7 @@ public final class RtContainerTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void killedWithNotFound() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_NOT_FOUND, ""
@@ -382,6 +399,7 @@ public final class RtContainerTestCase {
     @Test
     public void renamedOk() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_NO_CONTENT, ""
@@ -408,6 +426,7 @@ public final class RtContainerTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void renameWithNotFound() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_NOT_FOUND, ""
@@ -424,6 +443,7 @@ public final class RtContainerTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void renameWithServerError() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_INTERNAL_SERVER_ERROR, ""
@@ -440,6 +460,7 @@ public final class RtContainerTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void renameWithConflict() throws Exception {
         new RtContainer(
+            Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_CONFLICT, ""


### PR DESCRIPTION
PR for #114 

Introduced ``JsonResource`` which should be extended by all the Json entities of the API (Container, Image etc). This is for:

* polymorphism (we will be able to have common iteration logic, for instance)
* avoiding n+1 query problem.

Before this mechanism, the biggest issue was that the returned JsonObject (from the creation time) was not retained and thus, the client would have to call ``inspect()`` everytime they wanted some info about it, even data that can't be changed over time.