### PR TITLE
(#109) RtContainers.create(): URL encode the query parameters

### DIFF
--- a/src/main/java/com/amihaiemil/docker/RtContainers.java
+++ b/src/main/java/com/amihaiemil/docker/RtContainers.java
@@ -95,11 +95,16 @@ final class RtContainers implements Containers {
     public Container create(
         final String name, final JsonObject container
     ) throws IOException {
-        final String uri;
+        final URI uri;
         if(!name.isEmpty()) {
-            uri = this.baseUri.toString() + "/create?name=" + name;
+            uri = new UncheckedUriBuilder(
+                this.baseUri.toString().concat("/create")
+            ).addParameter("name", name)
+                .build();
         } else {
-            uri = this.baseUri.toString() + "/create";
+            uri = new UncheckedUriBuilder(
+                this.baseUri.toString().concat("/create")
+            ).build();
         }
         final HttpPost post = new HttpPost(uri);
         post.setEntity(new StringEntity(container.toString()));
@@ -119,7 +124,7 @@ final class RtContainers implements Containers {
             );
         }
         throw new UnexpectedResponseException(
-            uri, status, HttpStatus.SC_CREATED
+            uri.toString(), status, HttpStatus.SC_CREATED
         );
     }
 

--- a/src/test/java/com/amihaiemil/docker/RtContainersTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtContainersTestCase.java
@@ -273,4 +273,23 @@ public final class RtContainersTestCase {
             ), URI.create("http://localhost/test")
         ).create("image_name", json);
     }
+
+    /**
+     * Bug #109: RtContainers.create() must encode URL parameters.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void createEscapesNameParameter() throws Exception {
+        new RtContainers(
+            new AssertRequest(
+                new Response(HttpStatus.SC_CREATED, "{ \"Id\": \"df2419f4\" }"),
+                new Condition(
+                    "RtContainers.create() must encode URL parameter",
+                    req -> req.getRequestLine()
+                        .getUri().endsWith("name=Adrian+Toomes")
+                )
+            ),
+            URI.create("http://localhost/docker")
+        ).create("Adrian Toomes", "some/image");
+    }
 }


### PR DESCRIPTION
This PR:
* solves #109