### PR TITLE
(#100) Initial SSLContext implementation for SslHttpClient

### DIFF
--- a/src/main/java/com/amihaiemil/docker/RemoteDocker.java
+++ b/src/main/java/com/amihaiemil/docker/RemoteDocker.java
@@ -41,7 +41,7 @@ import org.apache.http.client.HttpClient;
  *  figure out how to create a remote Docker host and connect to it from Travis.
  *  Also, it will probably have to be paid (some machine on AWS or DO?).
  */
-public final class RemoteDocker extends RtDocker {
+final class RemoteDocker extends RtDocker {
 
     /**
      * Remote Docker engine. API version is 1.35 by default.
@@ -51,7 +51,7 @@ public final class RemoteDocker extends RtDocker {
      * @param storePwd Password for the keystore.
      * @param keyPwd Passphrase for the key.
      */
-    public RemoteDocker(
+    RemoteDocker(
         final URI uri, final Path keys, final Path trust,
         final char[] storePwd, final char[] keyPwd) {
         this(uri, "v1.35", keys, trust, storePwd, keyPwd);
@@ -66,7 +66,7 @@ public final class RemoteDocker extends RtDocker {
      * @param storePwd Password for the keystore.
      * @param keyPwd Passphrase for the key.
      */
-    public RemoteDocker(
+    RemoteDocker(
         final URI uri, final String version,
         final Path keys, final Path trust,
         final char[] storePwd, final char[] keyPwd) {
@@ -84,7 +84,7 @@ public final class RemoteDocker extends RtDocker {
      * @param client The http client to use.
      * @param uri Remote Docker URI.
      */
-    public RemoteDocker(final HttpClient client, final URI uri) {
+    RemoteDocker(final HttpClient client, final URI uri) {
         this(client, uri, "v1.35");
     }
 
@@ -96,7 +96,7 @@ public final class RemoteDocker extends RtDocker {
      * @param uri Remote Docker URI.
      * @param version API version (eg. v1.35).
      */
-    public RemoteDocker(
+    RemoteDocker(
         final HttpClient client, final URI uri, final String version
     ) {
         super(client, URI.create(uri.toString() + "/" + version));

--- a/src/main/java/com/amihaiemil/docker/RemoteDocker.java
+++ b/src/main/java/com/amihaiemil/docker/RemoteDocker.java
@@ -36,6 +36,7 @@ import org.apache.http.client.HttpClient;
  * @author George Aristy (george.aristy@gmail.com)
  * @version $Id$
  * @since 0.0.1
+ * @checkstyle ParameterNumber (150 lines)
  * @todo #68:30min Implement integration tests for RemoteDocker. We have to
  *  figure out how to create a remote Docker host and connect to it from Travis.
  *  Also, it will probably have to be paid (some machine on AWS or DO?).
@@ -45,24 +46,34 @@ public final class RemoteDocker extends RtDocker {
     /**
      * Remote Docker engine. API version is 1.35 by default.
      * @param uri Remote Docker URI.
-     * @param certs Path to the folder containing these 3:
-     *  CA certificate (ca.pem), client certificate (cert.pem)
-     *  and client key (key.pem).
+     * @param keys Path to the keystore.
+     * @param trust Path to the truststore.
+     * @param storePwd Password for the keystore.
+     * @param keyPwd Passphrase for the key.
      */
-    public RemoteDocker(final URI uri, final Path certs) {
-        this(uri, "v1.35", certs);
+    public RemoteDocker(
+        final URI uri, final Path keys, final Path trust,
+        final char[] storePwd, final char[] keyPwd) {
+        this(uri, "v1.35", keys, trust, storePwd, keyPwd);
     }
 
     /**
      * Remote Docker engine.
      * @param uri Remote Docker URI.
      * @param version API version (eg. v1.35).
-     * @param certs Path to the folder containing these 3:
-     *  CA certificate (ca.pem), client certificate (cert.pem)
-     *  and client key (key.pem).
+     * @param keys Path to the keystore.
+     * @param trust Path to the truststore.
+     * @param storePwd Password for the keystore.
+     * @param keyPwd Passphrase for the key.
      */
-    public RemoteDocker(final URI uri, final String version, final Path certs) {
-        this(new SslHttpClient(certs), uri, version);
+    public RemoteDocker(
+        final URI uri, final String version,
+        final Path keys, final Path trust,
+        final char[] storePwd, final char[] keyPwd) {
+        this(
+            new SslHttpClient(keys, trust, storePwd, keyPwd),
+            uri, version
+        );
     }
 
     /**

--- a/src/main/java/com/amihaiemil/docker/SslHttpClient.java
+++ b/src/main/java/com/amihaiemil/docker/SslHttpClient.java
@@ -27,6 +27,11 @@ package com.amihaiemil.docker;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
 
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -39,6 +44,7 @@ import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HttpContext;
+import org.apache.http.ssl.SSLContexts;
 
 /**
  * An HttpClient that works over a normal network socket.
@@ -62,12 +68,21 @@ final class SslHttpClient implements HttpClient {
      * @param certs Path to the folder containing the following certificates:
      *  ca.pem, cert.pem and key.pem.
      */
-    SslHttpClient(final Path certs) {
+    SslHttpClient(final Path certs, final char[] passwd) throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyStoreException, CertificateException, UnrecoverableKeyException, KeyManagementException {
         this(
             HttpClients.custom()
                 .setMaxConnPerRoute(10)
                 .setMaxConnTotal(10)
-                .build()
+                .setSSLContext(
+                    SSLContexts.custom()
+                        .loadTrustMaterial(
+                            certs.resolve("ca.pem").toFile()
+                        ).loadTrustMaterial(
+                            certs.resolve("cert.pem").toFile()
+                        ).loadKeyMaterial(
+                            certs.resolve("key.pem").toFile(), passwd, passwd
+                        ).build()
+                ).build()
         );
     }
 

--- a/src/test/java/com/amihaiemil/docker/SslHttpClientTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/SslHttpClientTestCase.java
@@ -39,6 +39,8 @@ import org.junit.Test;
  * @version $Id$
  * @since 0.0.1
  * @checkstyle MethodName (500 lines)
+ * @todo #100:30min Add more tests for the SslHttpClient, especially
+ *  integration tests.
  */
 public final class SslHttpClientTestCase {
     /**


### PR DESCRIPTION
This PR:
* Parametrizes key/trust stores for `SslHttpClient` as per #100 
* Differs a bit from the problem description in the way the user configures the keys: the user should just provide a path to their keystore where their keys are, while the server's public key should have been previously imported into their truststore, and the path to this truststore should be provided as well
* Leaves puzzle for adding tests for `SslHttpClient`
* Leaves puzzle for adding an insecure http client because someone may also wish to disable security on their docker API