### PR TITLE
ResourceIterator implemented for RtImages

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Image.java
+++ b/src/main/java/com/amihaiemil/docker/Image.java
@@ -35,7 +35,7 @@ import javax.json.JsonObject;
  * @see <a href="https://docs.docker.com/engine/api/v1.35/#tag/Image">Docker Images API</a>
  * @since 0.0.1
  */
-public interface Image {
+public interface Image extends JsonObject {
 
     /**
      * Return low-level information about this image. 

--- a/src/main/java/com/amihaiemil/docker/Images.java
+++ b/src/main/java/com/amihaiemil/docker/Images.java
@@ -38,14 +38,6 @@ import java.net.URL;
  *  Images interface. See the docs referenced above for more details.
  */
 public interface Images extends Iterable<Image> {
-    /**
-     * All images on the docker server.
-     * @return The images.
-     * @throws IOException If an I/O error occurs.
-     * @throws UnexpectedResponseException If the API responds with an 
-     *  unexpected status.
-     */
-    Iterable<Image> iterate() throws IOException, UnexpectedResponseException;
 
     /**
      * Creates an image by pulling it from a registry.

--- a/src/main/java/com/amihaiemil/docker/JsonResource.java
+++ b/src/main/java/com/amihaiemil/docker/JsonResource.java
@@ -89,7 +89,6 @@ abstract class JsonResource implements JsonObject {
 
     @Override
     public String getString(final String name, final String defaultValue) {
-//        new ResourcesIterator<Container>().
         return this.resource.getString(name, defaultValue);
     }
 

--- a/src/main/java/com/amihaiemil/docker/JsonResource.java
+++ b/src/main/java/com/amihaiemil/docker/JsonResource.java
@@ -89,6 +89,7 @@ abstract class JsonResource implements JsonObject {
 
     @Override
     public String getString(final String name, final String defaultValue) {
+//        new ResourcesIterator<Container>().
         return this.resource.getString(name, defaultValue);
     }
 

--- a/src/main/java/com/amihaiemil/docker/ReadJsonArray.java
+++ b/src/main/java/com/amihaiemil/docker/ReadJsonArray.java
@@ -25,48 +25,41 @@
  */
 package com.amihaiemil.docker;
 
-import java.net.URI;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ResponseHandler;
+import javax.json.Json;
+import javax.json.JsonArray;
+import java.io.IOException;
 
 /**
- * An Apache ResponseHandler that tries to match the Response's status code
- * with the expected one.
+ * Handler that reads a JsonArray from the response.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 0.0.1
+ * @since 0.0.
+ * @todo #84:30min Write some unit tests for this class, it is
+ *  currently only tested by RtImagesITCase#iteratesImages.
  */
-final class MatchStatus implements ResponseHandler<HttpResponse> {
+final class ReadJsonArray implements ResponseHandler<JsonArray> {
 
     /**
-     * Called URI.
+     * Handlers to be executed before actually reading the array.
      */
-    private final URI called;
-    
-    /**
-     * Expected status.
-     */
-    private final int expected;
-    
+    private final ResponseHandler<HttpResponse> other;
+
     /**
      * Ctor.
-     * @param called Called URI.
-     * @param expected Expected Http status code.
+     * @param other Handlers to be executed before actually reading the array.
      */
-    MatchStatus(final URI called, final int expected) {
-        this.called = called;
-        this.expected = expected;
+    ReadJsonArray(final ResponseHandler<HttpResponse> other) {
+        this.other = other;
     }
-    
+
     @Override
-    public HttpResponse handleResponse(final HttpResponse response) {
-        final int actual = response.getStatusLine().getStatusCode();
-        if(actual != this.expected) {
-            throw new UnexpectedResponseException(
-                this.called.toString(), actual, this.expected
-            );
-        }
-        return response;
+    public JsonArray handleResponse(final HttpResponse httpResponse)
+        throws IOException {
+        final HttpResponse resp = this.other.handleResponse(httpResponse);
+        return Json.createReader(
+            resp.getEntity().getContent()
+        ).readArray();
     }
-    
 }

--- a/src/main/java/com/amihaiemil/docker/ResourcesIterator.java
+++ b/src/main/java/com/amihaiemil/docker/ResourcesIterator.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2018, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.amihaiemil.docker;
+
+import javax.json.JsonObject;
+import java.util.Iterator;
+
+/**
+ * Iterator over Docker resources (Containers, Images etc).
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.1
+ */
+public class ResourcesIterator<T extends JsonObject> implements Iterator<T> {
+    @Override
+    public boolean hasNext() {
+        return false;
+    }
+
+    @Override
+    public T next() {
+        return null;
+    }
+}

--- a/src/main/java/com/amihaiemil/docker/RtImage.java
+++ b/src/main/java/com/amihaiemil/docker/RtImage.java
@@ -39,7 +39,7 @@ import org.apache.http.client.methods.HttpPost;
  * @version $Id$
  * @since 0.0.1
  */
-final class RtImage implements Image {
+final class RtImage extends JsonResource implements Image {
     /**
      * Apache HttpClient which sends the requests.
      */
@@ -52,10 +52,12 @@ final class RtImage implements Image {
 
     /**
      * Ctor.
+     * @param rep JsonObject representation of this Image.
      * @param client The http client.
      * @param uri The URI for this image.
      */
-    RtImage(final HttpClient client, final URI uri) {
+    RtImage(final JsonObject rep, final HttpClient client, final URI uri) {
+        super(rep);
         this.client = client;
         this.baseUri = uri;
     }

--- a/src/test/java/com/amihaiemil/docker/RtImageTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImageTestCase.java
@@ -52,6 +52,7 @@ public final class RtImageTestCase {
     @Test
     public void inspectsItself() throws Exception {
         final Image image = new RtImage(
+            Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_OK,
@@ -97,6 +98,7 @@ public final class RtImageTestCase {
     public void returnsHistory() {
         MatcherAssert.assertThat(
             new RtImage(
+                Json.createObjectBuilder().build(),
                 new AssertRequest(
                     new Response(
                         HttpStatus.SC_OK,
@@ -119,6 +121,7 @@ public final class RtImageTestCase {
     @Test
     public void deleteSendsCorrectRequest() throws Exception {
         new RtImage(
+            Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(HttpStatus.SC_OK),
                 new Condition(
@@ -144,6 +147,7 @@ public final class RtImageTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void deleteErrorOn404() throws Exception {
         new RtImage(
+            Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(HttpStatus.SC_NOT_FOUND)
             ),
@@ -159,6 +163,7 @@ public final class RtImageTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void deleteErrorOn409() throws Exception {
         new RtImage(
+            Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(HttpStatus.SC_CONFLICT)
             ),
@@ -174,6 +179,7 @@ public final class RtImageTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void deleteErrorOn500() throws Exception {
         new RtImage(
+            Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             ),
@@ -190,6 +196,7 @@ public final class RtImageTestCase {
     @Test
     public void tagsOk() throws Exception {
         new RtImage(
+            Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(HttpStatus.SC_CREATED),
                 new Condition(
@@ -215,6 +222,7 @@ public final class RtImageTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void tagErrorIfResponseIs400() throws Exception {
         new RtImage(
+            Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(HttpStatus.SC_BAD_REQUEST)
             ),
@@ -230,6 +238,7 @@ public final class RtImageTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void tagErrorIfResponseIs404() throws Exception {
         new RtImage(
+            Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(HttpStatus.SC_NOT_FOUND)
             ),
@@ -245,6 +254,7 @@ public final class RtImageTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void tagErrorIfResponseIs409() throws Exception {
         new RtImage(
+            Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(HttpStatus.SC_CONFLICT)
             ),
@@ -260,6 +270,7 @@ public final class RtImageTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void tagErrorIfResponseIs500() throws Exception {
         new RtImage(
+            Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             ),

--- a/src/test/java/com/amihaiemil/docker/RtImagesTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImagesTestCase.java
@@ -51,7 +51,7 @@ public final class RtImagesTestCase {
      * @throws Exception If an error occurs.
      */
     @Test
-    public void iterateReturnsImages() throws Exception {
+    public void iteratesImages() throws Exception {
         final AtomicInteger count = new AtomicInteger();
         new RtImages(
             new AssertRequest(
@@ -67,7 +67,7 @@ public final class RtImagesTestCase {
                         ).build().toString()
                 )
             ), URI.create("http://localhost")
-        ).iterate().forEach(image -> count.incrementAndGet());
+        ).forEach(image -> count.incrementAndGet());
         MatcherAssert.assertThat(
             count.get(),
             Matchers.is(2)
@@ -85,7 +85,7 @@ public final class RtImagesTestCase {
                 new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR, "")
             ),
             URI.create("http://localhost")
-        ).iterate();
+        ).iterator();
     }
 
     /**


### PR DESCRIPTION
RtImages now uses ``ResourceIterator`` to iterate over all the images, with the default filters. Wrote unit tests and integration tests.

Had to introduce ``ReadJsonArray`` response handler, which wraps ``MatchStatus`` because apparently once we pass a response handler to ``HttpClient.execute(...)``, it automatically closes the response and you cannot read from it after the handlers have executed. 