### PR TITLE
Images.pull, import and Image.history

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Image.java
+++ b/src/main/java/com/amihaiemil/docker/Image.java
@@ -49,10 +49,10 @@ public interface Image extends JsonObject {
     
     /**
      * Return parent layers of this Image.
-     * @return Images parent Images.
+     * @return An Iterable containing the parents of this Image.
      * @see <a href="https://docs.docker.com/engine/api/v1.35/#operation/ImageHistory">Image History</a>
      */
-    Images history();
+    Iterable<Image> history();
 
     /**
      * Remove an image, along with any untagged parent images that were

--- a/src/main/java/com/amihaiemil/docker/Images.java
+++ b/src/main/java/com/amihaiemil/docker/Images.java
@@ -40,19 +40,31 @@ import java.net.URL;
 public interface Images extends Iterable<Image> {
 
     /**
-     * Creates an image by pulling it from a registry.
+     * Pull an Image from the Docker registry.
      * @param name Name of the image to pull.
-     * @param source The URL from which the image can be retrieved.
-     * @param repo Repository name for the image when it is pulled.
      * @param tag Tag or digest for the image.
-     * @return This {@link Images}.
+     * @return The created {@link Image}.
      * @throws IOException If an I/O error occurs.
      * @throws UnexpectedResponseException If the API responds with an 
      *  unexpected status.
      * @checkstyle ParameterNumber (4 lines)
      */
-    Images create(
-        final String name, final URL source, final String repo, final String tag
+    Image pull(
+        final String name, final String tag
+    ) throws IOException, UnexpectedResponseException;
+
+    /**
+     * Import an Image.
+     * @param source The URL from which the image can be retrieved.
+     * @param repo Repository name given to an image when it is imported.
+     *   The repo may include a tag.
+     * @return The imported Image.
+     * @throws IOException If an I/O error occurs.
+     * @throws UnexpectedResponseException If the API responds with an
+     *  undexpected status.
+     */
+    Image importImage(
+        final URL source, final String repo
     ) throws IOException, UnexpectedResponseException;
 
     /**

--- a/src/main/java/com/amihaiemil/docker/RtImage.java
+++ b/src/main/java/com/amihaiemil/docker/RtImage.java
@@ -31,6 +31,7 @@ import javax.json.JsonObject;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 
 /**
@@ -69,9 +70,17 @@ final class RtImage extends JsonResource implements Image {
     }
 
     @Override
-    public Images history() {
-        return new RtImages(
-            this.client, URI.create(this.baseUri.toString() + "/history")
+    public Iterable<Image> history() {
+        return () -> new ResourcesIterator<>(
+            this.client,
+            new HttpGet(this.baseUri.toString().concat("/history")),
+            json -> new RtImage(
+                json,
+                 this.client,
+                URI.create(
+                    this.baseUri.toString() + "/" + json.getString("Id")
+                )
+            )
         );
     }
 

--- a/src/main/java/com/amihaiemil/docker/RtImage.java
+++ b/src/main/java/com/amihaiemil/docker/RtImage.java
@@ -76,10 +76,8 @@ final class RtImage extends JsonResource implements Image {
             new HttpGet(this.baseUri.toString().concat("/history")),
             json -> new RtImage(
                 json,
-                 this.client,
-                URI.create(
-                    this.baseUri.toString() + "/" + json.getString("Id")
-                )
+                this.client,
+                this.baseUri
             )
         );
     }

--- a/src/main/java/com/amihaiemil/docker/RtImages.java
+++ b/src/main/java/com/amihaiemil/docker/RtImages.java
@@ -34,6 +34,8 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 
+import javax.json.Json;
+
 /**
  * Runtime {@link Images}.
  * @author George Aristy (george.aristy@gmail.com)
@@ -61,16 +63,13 @@ final class RtImages implements Images {
         this.baseUri = uri;
     }
 
-    // @checkstyle ParameterNumber (4 lines)
     @Override
-    public Images create(
-        final String name, final URL source, final String repo, final String tag
+    public Image pull(
+        final String name, final String tag
     ) throws IOException, UnexpectedResponseException {
         final HttpPost create  = new HttpPost(
             new UncheckedUriBuilder(this.baseUri.toString().concat("/create"))
                 .addParameter("fromImage", name)
-                .addParameter("fromSrc", source.toString())
-                .addParameter("repo", repo)
                 .addParameter("tag", tag)
                 .build()
         );
@@ -79,10 +78,26 @@ final class RtImages implements Images {
                 create,
                 new MatchStatus(create.getURI(), HttpStatus.SC_OK)
             );
-            return this;
+            return new RtImage(
+                Json.createObjectBuilder().add("Name", name).build(),
+                this.client,
+                URI.create(
+                    this.baseUri.toString() + "/" + name
+                )
+            );
         } finally {
             create.releaseConnection();
         }
+    }
+
+    @Override
+    public Image importImage(
+        final URL source, final String repo
+    ) throws IOException, UnexpectedResponseException {
+        throw new UnsupportedOperationException(
+            "Not yet implemented. If you can contribute please,"
+            + " do it here: https://www.github.com/amihaiemil/docker-java-api"
+        );
     }
 
     @Override

--- a/src/test/java/com/amihaiemil/docker/RtImageITCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImageITCase.java
@@ -28,32 +28,34 @@ package com.amihaiemil.docker;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+
 import java.io.File;
 
 /**
- * Integration tests for {@link RtImages}.
+ * Integration tests for {@link RtImage}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
  */
-public final class RtImagesITCase {
+public final class RtImageITCase {
 
     /**
-     * {@link RtImages} can iterate over the Images, with the default filters.
-     * @throws Exception If an error occurs.
+     * An {@link RtImage} knows its history.
+     * @throws Exception If something goes wrong.
      */
     @Test
-    public void iteratesImages() throws Exception {
-        final Images images = new LocalDocker(
+    public void returnsHistory() throws Exception {
+        final Image img =  new LocalDocker(
             new File("/var/run/docker.sock")
-        ).images();
-        for(final Image img : images) {
+        ).images().pull("hello-world", "latest");
+        for(final Image parent:img.history()) {
             MatcherAssert.assertThat(
-                img.getInt("Created"), Matchers.notNullValue()
+                parent.getInt("Created"), Matchers.notNullValue()
             );
             MatcherAssert.assertThat(
-                img.getString("Id"), Matchers.startsWith("sha256:")
+                parent.getString("Id"), Matchers.notNullValue()
             );
         }
     }
+
 }

--- a/src/test/java/com/amihaiemil/docker/RtImageTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImageTestCase.java
@@ -109,7 +109,7 @@ public final class RtImageTestCase {
             ).history(),
             Matchers.allOf(
                 Matchers.notNullValue(),
-                Matchers.instanceOf(Images.class)
+                Matchers.instanceOf(Iterable.class)
             )
         );
     }

--- a/src/test/java/com/amihaiemil/docker/RtImagesTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImagesTestCase.java
@@ -29,7 +29,6 @@ import com.amihaiemil.docker.mock.AssertRequest;
 import com.amihaiemil.docker.mock.Condition;
 import com.amihaiemil.docker.mock.Response;
 import java.net.URI;
-import java.net.URL;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.json.Json;
 import org.apache.http.HttpStatus;
@@ -48,10 +47,9 @@ public final class RtImagesTestCase {
     /**
      * Must return the same number of images as there are elements in the
      * json array returned by the service.
-     * @throws Exception If an error occurs.
      */
     @Test
-    public void iteratesImages() throws Exception {
+    public void iteratesImages() {
         final AtomicInteger count = new AtomicInteger();
         new RtImages(
             new AssertRequest(
@@ -110,7 +108,7 @@ public final class RtImagesTestCase {
     }
 
     /**
-     * {@link RtImages#create(String, URL, String, String)} must construct the
+     * {@link RtImages#pull(String, String)} must construct the
      * URL with parameters correctly.
      * <p>
      * Notice the escaped characters for the 'fromSrc' parameter's value.
@@ -128,17 +126,13 @@ public final class RtImagesTestCase {
                         System.out.println(req.getRequestLine().getUri());
                         return req.getRequestLine().getUri().endsWith(
                             // @checkstyle LineLength (1 line)
-                            "/create?fromImage=testImage&fromSrc=http%3A%2F%2Fdocker.registry.com&repo=testRepo&tag=1.23"
+                            "/create?fromImage=testImage&tag=1.23"
                         );
                     }
                 )
             ),
             URI.create("http://localhost")
-        )
-            .create(
-                "testImage", new URL("http://docker.registry.com"),
-                "testRepo", "1.23"
-        );
+        ).pull("testImage", "1.23");
     }
 
     /**
@@ -153,7 +147,7 @@ public final class RtImagesTestCase {
                 new Response(HttpStatus.SC_NOT_FOUND)
             ),
             URI.create("http://localhost")
-        ).create("", new URL("http://registry.docker.com"), "", "");
+        ).pull("", "");
     }
 
     /**
@@ -168,7 +162,7 @@ public final class RtImagesTestCase {
                 new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             ),
             URI.create("http://localhost")
-        ).create("", new URL("http://registry.docker.com"), "", "");
+        ).pull("", "");
     }
 
     /**


### PR DESCRIPTION
PR for #123 

Separated ``Images.create`` into ``Images.pull`` and ``Images.import`` since it simplifies stuff. Even the API documentation suggests that they should be separated (it dictates which param should be used in which of the 2 scenarios).

Also cleared ``Image.history``, it now returns ``Iterable<image>``