### PR TITLE
(#108) Add the body to the UnexpectedResponseException

### DIFF
--- a/src/main/java/com/amihaiemil/docker/JsonResource.java
+++ b/src/main/java/com/amihaiemil/docker/JsonResource.java
@@ -28,6 +28,7 @@ package com.amihaiemil.docker;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import javax.json.JsonArray;
 import javax.json.JsonNumber;
 import javax.json.JsonObject;
@@ -53,6 +54,14 @@ abstract class JsonResource implements JsonObject {
      * The JsonObject resource in question.
      */
     private final JsonObject resource;
+
+    /**
+     * Ctor.
+     * @param resource Supply the JsonObject.
+     */
+    JsonResource(final Supplier<JsonObject> resource) {
+        this(resource.get());
+    }
     
     /**
      * Ctor.

--- a/src/main/java/com/amihaiemil/docker/MatchStatus.java
+++ b/src/main/java/com/amihaiemil/docker/MatchStatus.java
@@ -63,7 +63,8 @@ final class MatchStatus implements ResponseHandler<HttpResponse> {
         final int actual = response.getStatusLine().getStatusCode();
         if(actual != this.expected) {
             throw new UnexpectedResponseException(
-                this.called.toString(), actual, this.expected
+                this.called.toString(), actual,
+                this.expected, new PayloadOf(response)
             );
         }
         return response;

--- a/src/main/java/com/amihaiemil/docker/PayloadOf.java
+++ b/src/main/java/com/amihaiemil/docker/PayloadOf.java
@@ -26,16 +26,8 @@
 package com.amihaiemil.docker;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Supplier;
 import javax.json.Json;
-import javax.json.JsonArray;
-import javax.json.JsonNumber;
 import javax.json.JsonObject;
-import javax.json.JsonString;
-import javax.json.JsonValue;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
@@ -48,12 +40,7 @@ import org.apache.http.HttpResponse;
  * @since 0.0.1
  * @todo #108:30min Add tests for PayloadOf.
  */
-final class PayloadOf implements JsonObject {
-    /**
-     * The request's payload.
-     */
-    private final JsonObject json;
-
+final class PayloadOf extends JsonResource {
     /**
      * Ctor.
      * 
@@ -61,7 +48,7 @@ final class PayloadOf implements JsonObject {
      * @throws IllegalStateException if the request's payload cannot be read
      */
     PayloadOf(final HttpRequest request) {
-        this(() -> {
+        super(() -> {
             try {
                 final JsonObject body;
                 if (request instanceof HttpEntityEnclosingRequest) {
@@ -87,7 +74,7 @@ final class PayloadOf implements JsonObject {
      * @throws IllegalStateException if the response's payload cannot be read
      */
     PayloadOf(final HttpResponse response) {
-        this(() -> {
+        super(() -> {
             try {
                 return Json.createReader(
                     response.getEntity().getContent()
@@ -98,134 +85,5 @@ final class PayloadOf implements JsonObject {
                 );
             }
         });
-    }
-
-    /**
-     * Ctor.
-     * @param json The json.
-     * @throws IllegalStateException if the payload cannot be read
-     */
-    private PayloadOf(final Supplier<JsonObject> json) {
-        this.json = json.get();
-    }
-
-    @Override
-    public JsonArray getJsonArray(final String name) {
-        return this.json.getJsonArray(name);
-    }
-
-    @Override
-    public JsonObject getJsonObject(final String name) {
-        return this.json.getJsonObject(name);
-    }
-
-    @Override
-    public JsonNumber getJsonNumber(final String name) {
-        return this.json.getJsonNumber(name);
-    }
-
-    @Override
-    public JsonString getJsonString(final String name) {
-        return this.json.getJsonString(name);
-    }
-
-    @Override
-    public String getString(final String name) {
-        return this.json.getString(name);
-    }
-
-    @Override
-    public String getString(final String name, final String defaultValue) {
-        return this.json.getString(name, defaultValue);
-    }
-
-    @Override
-    public int getInt(final String name) {
-        return this.json.getInt(name);
-    }
-
-    @Override
-    public int getInt(final String name, final int defaultValue) {
-        return this.json.getInt(name, defaultValue);
-    }
-
-    @Override
-    public boolean getBoolean(final String name) {
-        return this.json.getBoolean(name);
-    }
-
-    @Override
-    public boolean getBoolean(final String name, final boolean defaultValue) {
-        return this.json.getBoolean(name, defaultValue);
-    }
-
-    @Override
-    public boolean isNull(final String name) {
-        return this.json.isNull(name);
-    }
-
-    @Override
-    public ValueType getValueType() {
-        return this.json.getValueType();
-    }
-
-    @Override
-    public int size() {
-        return this.json.size();
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return this.json.isEmpty();
-    }
-
-    @Override
-    public boolean containsKey(final Object key) {
-        return this.json.containsKey(key);
-    }
-
-    @Override
-    public boolean containsValue(final Object value) {
-        return this.json.containsValue(value);
-    }
-
-    @Override
-    public JsonValue get(final Object key) {
-        return this.json.get(key);
-    }
-
-    @Override
-    public JsonValue put(final String key, final JsonValue value) {
-        return this.json.put(key, value);
-    }
-
-    @Override
-    public JsonValue remove(final Object key) {
-        return this.json.remove(key);
-    }
-
-    @Override
-    public void putAll(final Map<? extends String, ? extends JsonValue> map) {
-        this.json.putAll(map);
-    }
-
-    @Override
-    public void clear() {
-        this.json.clear();
-    }
-
-    @Override
-    public Set<String> keySet() {
-        return this.json.keySet();
-    }
-
-    @Override
-    public Collection<JsonValue> values() {
-        return this.json.values();
-    }
-
-    @Override
-    public Set<Entry<String, JsonValue>> entrySet() {
-        return this.json.entrySet();
     }
 }

--- a/src/main/java/com/amihaiemil/docker/UnexpectedResponseException.java
+++ b/src/main/java/com/amihaiemil/docker/UnexpectedResponseException.java
@@ -25,6 +25,8 @@
  */
 package com.amihaiemil.docker;
 
+import javax.json.JsonObject;
+
 /**
  * Signals that the response received from the docker API was not expected.
  * For instance, it is thrown when Container#inspect() gets a different
@@ -51,19 +53,28 @@ public final class UnexpectedResponseException extends RuntimeException {
     private final int expectedStatus;
 
     /**
+     * The response's body.
+     */
+    private final JsonObject payload;
+
+    /**
      * Ctor.
      * @param endpoint Endpoint that was called.
      * @param actualStatus Received status.
      * @param expectedStatus Expected status.
+     * @param body The response's body.
      */
+    // @checkstyle ParameterNumber (3 lines)
     public UnexpectedResponseException(
-        final String endpoint, final int actualStatus, final int expectedStatus
+        final String endpoint, final int actualStatus,
+        final int expectedStatus, final JsonObject body
     ) {
         // @checkstyle LineLength (1 line)
         super("Expected status " + expectedStatus + " but got " + actualStatus + " when calling " + endpoint);
         this.endpoint = endpoint;
         this.actualStatus = actualStatus;
         this.expectedStatus = expectedStatus;
+        this.payload = body;
     }
 
     /**
@@ -90,4 +101,11 @@ public final class UnexpectedResponseException extends RuntimeException {
         return this.expectedStatus;
     }
 
+    /**
+     * Payload received in the response from the Docker API.
+     * @return The body of the response.
+     */
+    public JsonObject payload() {
+        return this.payload;
+    }
 }

--- a/src/main/java/com/amihaiemil/docker/UnexpectedResponseException.java
+++ b/src/main/java/com/amihaiemil/docker/UnexpectedResponseException.java
@@ -69,8 +69,11 @@ public final class UnexpectedResponseException extends RuntimeException {
         final String endpoint, final int actualStatus,
         final int expectedStatus, final JsonObject body
     ) {
-        // @checkstyle LineLength (1 line)
-        super("Expected status " + expectedStatus + " but got " + actualStatus + " when calling " + endpoint);
+        super(String.format(
+            // @checkstyle LineLength (1 line)
+            "Expected status %s but got %s when calling %s. Response body was %s",
+            expectedStatus, actualStatus, endpoint, body.toString()
+        ));
         this.endpoint = endpoint;
         this.actualStatus = actualStatus;
         this.expectedStatus = expectedStatus;

--- a/src/test/java/com/amihaiemil/docker/InspectionTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/InspectionTestCase.java
@@ -48,7 +48,7 @@ public final class InspectionTestCase {
         final String url = "http://localhost/docker";
         new Inspection(
             new AssertRequest(
-                new Response(HttpStatus.SC_OK, "{}"),
+                new Response(HttpStatus.SC_OK),
                 new Condition(
                     "Request method must be GET.",
                     req -> "GET".equals(req.getRequestLine().getMethod())
@@ -71,7 +71,7 @@ public final class InspectionTestCase {
     public void unexpectedResponseErrorIfResponseNot200() throws Exception {
         new Inspection(
             new AssertRequest(
-                new Response(HttpStatus.SC_NOT_FOUND, "")
+                new Response(HttpStatus.SC_NOT_FOUND)
             ),
             "http://localhost"
         );

--- a/src/test/java/com/amihaiemil/docker/MatchStatusTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/MatchStatusTestCase.java
@@ -49,7 +49,7 @@ public final class MatchStatusTestCase {
     @Test(expected = UnexpectedResponseException.class)
     public void complainsOnDifferentStatus() throws Exception {
         new MatchStatus(URI.create("/test/ur"), HttpStatus.SC_OK)
-            .handleResponse(new Response(HttpStatus.SC_NOT_FOUND, ""));
+            .handleResponse(new Response(HttpStatus.SC_NOT_FOUND));
     }
     
     /**
@@ -59,7 +59,7 @@ public final class MatchStatusTestCase {
      */
     @Test
     public void returnsResponseOnMatch() throws Exception {
-        final HttpResponse resp = new Response(HttpStatus.SC_OK, "");
+        final HttpResponse resp = new Response(HttpStatus.SC_OK);
         MatcherAssert.assertThat(
             new MatchStatus(URI.create("/test/ur"), HttpStatus.SC_OK)
                 .handleResponse(resp),

--- a/src/test/java/com/amihaiemil/docker/RtContainerTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtContainerTestCase.java
@@ -113,7 +113,7 @@ public final class RtContainerTestCase {
         new RtContainer(
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
-                new Response(HttpStatus.SC_NOT_FOUND, "")
+                new Response(HttpStatus.SC_NOT_FOUND)
             ),
             URI.create("http://localhost:80/1.30/containers/123")
         ).inspect();
@@ -129,7 +129,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NO_CONTENT, ""
+                    HttpStatus.SC_NO_CONTENT
                 ),
                 new Condition(
                     "Method should be a POST",
@@ -154,7 +154,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ""
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -171,7 +171,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NOT_FOUND, ""
+                    HttpStatus.SC_NOT_FOUND
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -188,7 +188,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NOT_MODIFIED, ""
+                    HttpStatus.SC_NOT_MODIFIED
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -205,7 +205,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NO_CONTENT, ""
+                    HttpStatus.SC_NO_CONTENT
                 ),
                 new Condition(
                     "Method should be a POST",
@@ -230,7 +230,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ""
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -247,7 +247,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NOT_FOUND, ""
+                    HttpStatus.SC_NOT_FOUND
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -264,7 +264,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NOT_MODIFIED, ""
+                    HttpStatus.SC_NOT_MODIFIED
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -281,7 +281,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "9403").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NO_CONTENT, ""
+                    HttpStatus.SC_NO_CONTENT
                 ),
                 new Condition(
                     "Method should be a POST",
@@ -308,7 +308,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ""
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -326,7 +326,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NOT_FOUND, ""
+                    HttpStatus.SC_NOT_FOUND
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -343,7 +343,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NO_CONTENT, ""
+                    HttpStatus.SC_NO_CONTENT
                 ),
                 new Condition(
                     "Method should be a POST",
@@ -368,7 +368,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ""
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -385,7 +385,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NOT_FOUND, ""
+                    HttpStatus.SC_NOT_FOUND
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -402,7 +402,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NO_CONTENT, ""
+                    HttpStatus.SC_NO_CONTENT
                 ),
                 new Condition(
                     "Method should be a POST",
@@ -429,7 +429,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NOT_FOUND, ""
+                    HttpStatus.SC_NOT_FOUND
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -446,7 +446,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ""
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -463,7 +463,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().add("Id", "123").build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_CONFLICT, ""
+                    HttpStatus.SC_CONFLICT
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -480,7 +480,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NO_CONTENT, ""
+                    HttpStatus.SC_NO_CONTENT
                 ),
                 new Condition(
                     "Method should be a DELETE",
@@ -507,7 +507,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_BAD_REQUEST, ""
+                    HttpStatus.SC_BAD_REQUEST
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -524,7 +524,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NOT_FOUND, ""
+                    HttpStatus.SC_NOT_FOUND
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -541,7 +541,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_CONFLICT, ""
+                    HttpStatus.SC_CONFLICT
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")
@@ -558,7 +558,7 @@ public final class RtContainerTestCase {
             Json.createObjectBuilder().build(),
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR, ""
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR
                 )
             ),
             URI.create("http://localhost:80/1.30/containers/123")

--- a/src/test/java/com/amihaiemil/docker/RtContainersTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtContainersTestCase.java
@@ -27,7 +27,6 @@ package com.amihaiemil.docker;
 
 import com.amihaiemil.docker.mock.AssertRequest;
 import com.amihaiemil.docker.mock.Condition;
-import com.amihaiemil.docker.mock.PayloadOf;
 import com.amihaiemil.docker.mock.Response;
 import java.io.IOException;
 import java.net.URI;
@@ -107,7 +106,7 @@ public final class RtContainersTestCase {
     public void iterateFailsIfResponseIs500() throws Exception {
         new RtContainers(
             new AssertRequest(
-                new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR, "")
+                new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             ),
             URI.create("http://localhost")
         ).iterator();
@@ -121,7 +120,7 @@ public final class RtContainersTestCase {
     public void iterateFailsIfResponseIs400() throws Exception {
         new RtContainers(
             new AssertRequest(
-                new Response(HttpStatus.SC_BAD_REQUEST, "")
+                new Response(HttpStatus.SC_BAD_REQUEST)
             ),
             URI.create("http://localhost")
         ).iterator();
@@ -190,8 +189,7 @@ public final class RtContainersTestCase {
         new RtContainers(
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_BAD_REQUEST,
-                    ""
+                    HttpStatus.SC_BAD_REQUEST
                 )
             ), URI.create("http://localhost/test")
         ).create("some_image");
@@ -206,8 +204,7 @@ public final class RtContainersTestCase {
         new RtContainers(
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NOT_FOUND,
-                    ""
+                    HttpStatus.SC_NOT_FOUND
                 )
             ), URI.create("http://localhost/test")
         ).create("some_image");
@@ -222,8 +219,7 @@ public final class RtContainersTestCase {
         new RtContainers(
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_NOT_ACCEPTABLE,
-                    ""
+                    HttpStatus.SC_NOT_ACCEPTABLE
                 )
             ), URI.create("http://localhost/test")
         ).create("some_image");
@@ -238,8 +234,7 @@ public final class RtContainersTestCase {
         new RtContainers(
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_CONFLICT,
-                    ""
+                    HttpStatus.SC_CONFLICT
                 )
             ), URI.create("http://localhost/test")
         ).create("some_image");
@@ -254,8 +249,7 @@ public final class RtContainersTestCase {
         new RtContainers(
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
-                    ""
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR
                 )
             ), URI.create("http://localhost/test")
         ).create("some_image");

--- a/src/test/java/com/amihaiemil/docker/RtImagesTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImagesTestCase.java
@@ -101,7 +101,7 @@ public final class RtImagesTestCase {
     public void iterateFailsIfResponseIs500() throws Exception {
         new RtImages(
             new AssertRequest(
-                new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR, "")
+                new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             ),
             URI.create("http://localhost")
         ).iterator();

--- a/src/test/java/com/amihaiemil/docker/RtSwarmTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtSwarmTestCase.java
@@ -27,7 +27,6 @@ package com.amihaiemil.docker;
 
 import com.amihaiemil.docker.mock.AssertRequest;
 import com.amihaiemil.docker.mock.Condition;
-import com.amihaiemil.docker.mock.PayloadOf;
 import com.amihaiemil.docker.mock.Response;
 import java.net.URI;
 import org.apache.http.HttpStatus;
@@ -54,8 +53,7 @@ public final class RtSwarmTestCase {
         new RtSwarm(
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_OK,
-                    "{}"
+                    HttpStatus.SC_OK
                 ),
                 new Condition(
                     "Request method should be POST",
@@ -81,8 +79,7 @@ public final class RtSwarmTestCase {
         new RtSwarm(
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_OK,
-                    "{}"
+                    HttpStatus.SC_OK
                 ),
                 new Condition(
                     "Request method should be POST",
@@ -108,8 +105,7 @@ public final class RtSwarmTestCase {
         new RtSwarm(
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
-                    "Internal Error"
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR
                 )
             ),
             URI.create("http://localhost/swarm")
@@ -125,8 +121,7 @@ public final class RtSwarmTestCase {
         new RtSwarm(
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_SERVICE_UNAVAILABLE,
-                    "Internal Error"
+                    HttpStatus.SC_SERVICE_UNAVAILABLE
                 )
             ),
             URI.create("http://localhost/swarm")
@@ -189,7 +184,7 @@ public final class RtSwarmTestCase {
     public void inspectThrowsErrorIfResponseIs404() throws Exception {
         new RtSwarm(
             new AssertRequest(
-                new Response(HttpStatus.SC_NOT_FOUND, "")
+                new Response(HttpStatus.SC_NOT_FOUND)
             ), URI.create("http://localhost")
         ).inspect();
     }
@@ -203,7 +198,7 @@ public final class RtSwarmTestCase {
     public void inspectThrowsErrorIfResponseIs500() throws Exception {
         new RtSwarm(
             new AssertRequest(
-                new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR, "")
+                new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             ), URI.create("http://localhost")
         ).inspect();
     }
@@ -217,7 +212,7 @@ public final class RtSwarmTestCase {
     public void inspectThrowsErrorIfResponseIs503() throws Exception {
         new RtSwarm(
             new AssertRequest(
-                new Response(HttpStatus.SC_SERVICE_UNAVAILABLE, "")
+                new Response(HttpStatus.SC_SERVICE_UNAVAILABLE)
             ), URI.create("http://localhost")
         ).inspect();
     }
@@ -233,7 +228,7 @@ public final class RtSwarmTestCase {
         final String listenAddress = "172.27.9.10";
         new RtSwarm(
             new AssertRequest(
-                new Response(HttpStatus.SC_OK, "sometoken123"),
+                new Response(HttpStatus.SC_OK),
                 new Condition(
                     "Request method must be POST.",
                     req -> "POST".equals(req.getRequestLine().getMethod())
@@ -288,7 +283,7 @@ public final class RtSwarmTestCase {
     public void initUnexpectedErrorIfResponseIsNot200() throws Exception {
         new RtSwarm(
             new AssertRequest(
-                new Response(HttpStatus.SC_BAD_REQUEST, "")
+                new Response(HttpStatus.SC_BAD_REQUEST)
             ),
             URI.create("http://docker")
         ).init("123");

--- a/src/test/java/com/amihaiemil/docker/UnexpectedResponseExceptionTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/UnexpectedResponseExceptionTestCase.java
@@ -25,6 +25,8 @@
  */
 package com.amihaiemil.docker;
 
+import javax.json.Json;
+import javax.json.JsonObject;
 import org.apache.http.HttpStatus;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -45,7 +47,8 @@ public final class UnexpectedResponseExceptionTestCase {
     public void returnsActualStatus() {
         MatcherAssert.assertThat(
             new UnexpectedResponseException(
-                "/uri", HttpStatus.SC_NOT_FOUND, HttpStatus.SC_OK
+                "/uri", HttpStatus.SC_NOT_FOUND,
+                HttpStatus.SC_OK, Json.createObjectBuilder().build()
             ).actualStatus(),
             Matchers.equalTo(HttpStatus.SC_NOT_FOUND)
         );
@@ -58,7 +61,8 @@ public final class UnexpectedResponseExceptionTestCase {
     public void returnsExpectedStatus() {
         MatcherAssert.assertThat(
             new UnexpectedResponseException(
-                "/uri", HttpStatus.SC_NOT_FOUND, HttpStatus.SC_OK
+                "/uri", HttpStatus.SC_NOT_FOUND,
+                HttpStatus.SC_OK, Json.createObjectBuilder().build()
             ).expectedStatus(),
             Matchers.equalTo(HttpStatus.SC_OK)
         );
@@ -71,7 +75,8 @@ public final class UnexpectedResponseExceptionTestCase {
     public void returnsEndpoint() {
         MatcherAssert.assertThat(
             new UnexpectedResponseException(
-                "/uri", HttpStatus.SC_NOT_FOUND, HttpStatus.SC_OK
+                "/uri", HttpStatus.SC_NOT_FOUND,
+                HttpStatus.SC_OK, Json.createObjectBuilder().build()
             ).endpoint(),
             Matchers.equalTo("/uri")
         );
@@ -84,11 +89,27 @@ public final class UnexpectedResponseExceptionTestCase {
     public void returnsMessage() {
         MatcherAssert.assertThat(
             new UnexpectedResponseException(
-                "/uri", HttpStatus.SC_NOT_FOUND, HttpStatus.SC_OK
+                "/uri", HttpStatus.SC_NOT_FOUND,
+                HttpStatus.SC_OK, Json.createObjectBuilder().build()
             ).getMessage(),
             Matchers.equalTo(
                 "Expected status 200 but got 404 when calling /uri"
             )
+        );
+    }
+
+    /**
+     * UnexpectedResponseException returns the payload.
+     */
+    @Test
+    public void returnsPayload() {
+        final JsonObject payload = Json.createObjectBuilder().build();
+        MatcherAssert.assertThat(
+            new UnexpectedResponseException(
+                "/uri", HttpStatus.SC_OK,
+                HttpStatus.SC_OK, payload
+            ).payload(),
+            Matchers.is(payload)
         );
     }
 }

--- a/src/test/java/com/amihaiemil/docker/UnexpectedResponseExceptionTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/UnexpectedResponseExceptionTestCase.java
@@ -92,9 +92,26 @@ public final class UnexpectedResponseExceptionTestCase {
                 "/uri", HttpStatus.SC_NOT_FOUND,
                 HttpStatus.SC_OK, Json.createObjectBuilder().build()
             ).getMessage(),
-            Matchers.equalTo(
-                "Expected status 200 but got 404 when calling /uri"
+            Matchers.startsWith(
+                // @checkstyle LineLength (1 line)
+                "Expected status 200 but got 404 when calling /uri. Response body was"
             )
+        );
+    }
+
+    /**
+     * UnexpectedResponseException appends the payload to the message.
+     */
+    @Test
+    public void returnsMessageWithPayload() {
+        final JsonObject payload = Json.createObjectBuilder()
+            .add("message", "Some error")
+            .build();
+        MatcherAssert.assertThat(
+            new UnexpectedResponseException(
+                "/uri", HttpStatus.SC_OK, HttpStatus.SC_OK, payload
+            ).getMessage(),
+            Matchers.endsWith(payload.toString())
         );
     }
 

--- a/src/test/java/com/amihaiemil/docker/mock/Response.java
+++ b/src/test/java/com/amihaiemil/docker/mock/Response.java
@@ -72,7 +72,7 @@ public final class Response implements HttpResponse {
      * @param status The {@link HttpStatus http status code}
      */
     public Response(final int status) {
-        this(status, "");
+        this(status, "{}");
     }
 
     /**


### PR DESCRIPTION
This PR:
* solves #108 
* Adds `UnexpectedResponseException.payload()`
* Promotes `PayloadOf` from test packages to production packages as a package-private class
* Does small fix to a bunch of test cases that started to fail as soon as we started parsing the HttpResponse non-json payloads
* Leaves puzzle for adding tests to `PayloadOf`