### PR TITLE
(#133) Injecting JsonObject parameter and JsonObject response to RtContainer

### DIFF
--- a/src/main/java/com/amihaiemil/docker/RtContainers.java
+++ b/src/main/java/com/amihaiemil/docker/RtContainers.java
@@ -36,6 +36,7 @@ import javax.json.JsonObject;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Iterator;
+import javax.json.JsonObjectBuilder;
 
 /**
  * Containers API.
@@ -117,8 +118,11 @@ final class RtContainers implements Containers {
                     new MatchStatus(post.getURI(), HttpStatus.SC_CREATED)
                 )
             );
+            final JsonObjectBuilder contr = Json.createObjectBuilder();
+            container.forEach(contr::add);
+            json.forEach(contr::add);
             return new RtContainer(
-                json,
+                contr.build(),
                 this.client,
                 URI.create(
                     this.baseUri.toString() + "/" + json.getString("Id")

--- a/src/test/java/com/amihaiemil/docker/RtContainersTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtContainersTestCase.java
@@ -136,7 +136,8 @@ public final class RtContainersTestCase {
         new RtContainers(
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_CREATED, "{ \"Id\": \"df2419f4\" }"
+                    HttpStatus.SC_CREATED,
+                    "{ \"Id\": \"df2419f4\", \"Warnings\": [ ]}"
                 ),
                 new Condition(
                     "The 'Content-Type' header must be set.",
@@ -172,7 +173,7 @@ public final class RtContainersTestCase {
                 new AssertRequest(
                     new Response(
                         HttpStatus.SC_CREATED,
-                        "{ \"Id\": \"df2419f4\" }"
+                        "{ \"Id\": \"df2419f4\", \"Warnings\": [ ]}"
                     )
                 ), URI.create("http://localhost/test")
             ).create("some_image"),
@@ -266,7 +267,8 @@ public final class RtContainersTestCase {
         new RtContainers(
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_CREATED, "{ \"Id\": \"df2419f4\" }"
+                    HttpStatus.SC_CREATED,
+                    "{ \"Id\": \"df2419f4\", \"Warnings\": [ ]}"
                 ),
                 new Condition(
                     "Resource path must be /create?name=some_name",
@@ -292,7 +294,8 @@ public final class RtContainersTestCase {
         new RtContainers(
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_CREATED, "{ \"Id\": \"df2419f4\" }"
+                    HttpStatus.SC_CREATED,
+                    "{ \"Id\": \"df2419f4\", \"Warnings\": [ ]}"
                 ),
                 new Condition(
                     "Resource path must be /create",
@@ -327,7 +330,8 @@ public final class RtContainersTestCase {
         new RtContainers(
             new AssertRequest(
                 new Response(
-                    HttpStatus.SC_CREATED, "{ \"Id\": \"df2419f4\" }"
+                    HttpStatus.SC_CREATED,
+                    "{ \"Id\": \"df2419f4\", \"Warnings\": [ ]}"
                 ),
                 new Condition(
                     "Resource path must be /create?name=image_name",
@@ -356,7 +360,10 @@ public final class RtContainersTestCase {
     public void createEscapesNameParameter() throws Exception {
         new RtContainers(
             new AssertRequest(
-                new Response(HttpStatus.SC_CREATED, "{ \"Id\": \"df2419f4\" }"),
+                new Response(
+                    HttpStatus.SC_CREATED,
+                    "{ \"Id\": \"df2419f4\", \"Warnings\": [ ]}"
+                ),
                 new Condition(
                     "RtContainers.create() must encode URL parameter",
                     req -> req.getRequestLine()
@@ -365,5 +372,49 @@ public final class RtContainersTestCase {
             ),
             URI.create("http://localhost/docker")
         ).create("Adrian Toomes", "some/image");
+    }
+
+    /**
+     * RtContainers.create() returns an RtContainer with the given parameter.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void createsContainerWithGivenParameters() throws Exception {
+        MatcherAssert.assertThat(
+            new RtContainers(
+                new AssertRequest(
+                    new Response(
+                        HttpStatus.SC_CREATED,
+                        "{ \"Id\": \"df2419f4\", \"Warnings\": [ ]}"
+                    )
+                ), URI.create("http://localhost/test")
+            ).create(
+                Json.createObjectBuilder()
+                    .add("Image", "ubuntu").build()
+            ).getString("Image"),
+            Matchers.is("ubuntu")
+        );
+    }
+
+    /**
+     * RtContainers.create() returns an RtContainer with the docker id.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void createsContainerWithId() throws Exception {
+        MatcherAssert.assertThat(
+            new RtContainers(
+                new AssertRequest(
+                    new Response(
+                        HttpStatus.SC_CREATED,
+                        "{ \"Id\": \"df2419f4\", \"Warnings\": [ ] }"
+                    )
+                ), URI.create("http://localhost/test")
+            ).create(
+                Json.createObjectBuilder()
+                    .add("Image", "ubuntu").build()
+            ).getString("Id"),
+            Matchers.is("df2419f4")
+        );
     }
 }


### PR DESCRIPTION
For #133.

My solution was to merge both JSON objects and pass that to `RtContainer`. The merge is done by building a new `JsonObject` from scratch because `JsonObject`s are immutable.