### PR TITLE
Added ListedImages and made RtImages abstract

### DIFF
--- a/src/main/java/com/amihaiemil/docker/FilteredImages.java
+++ b/src/main/java/com/amihaiemil/docker/FilteredImages.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2018, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.amihaiemil.docker;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import java.net.URI;
+import java.util.Iterator;
+
+/**
+ * These are some Images after applying a filter.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.3
+ */
+final class FilteredImages extends RtImages {
+
+    /**
+     * Ctor.
+     * @param client The http client.
+     * @param uri The URI for this Images API.
+     * @param dkr The docker entry point.
+     * @checkstyle ParameterNumber (10 lines)
+     */
+    FilteredImages(final HttpClient client, final URI uri, final Docker dkr) {
+        super(client, uri, dkr);
+    }
+
+    @Override
+    public Iterator<Image> iterator() {
+        return new ResourcesIterator<>(
+            super.client(),
+            new HttpGet(super.baseUri().toString().concat("/json")),
+            img -> new RtImage(
+                img,
+                super.client(),
+                URI.create(
+                    super.baseUri().toString() + "/" + img.getString("Id")
+                ),
+                super.docker()
+            )
+        );
+    }
+}

--- a/src/main/java/com/amihaiemil/docker/Images.java
+++ b/src/main/java/com/amihaiemil/docker/Images.java
@@ -36,6 +36,16 @@ import java.net.URL;
  * @since 0.0.1
  * @todo #98:30min Continue implementing the rest of the operations for the
  *  Images interface. See the docs referenced above for more details.
+ * @todo #144:30min Add the filter(Map<String, String>) method which will filter
+ *  the given instance of Images. For instance:
+ *  <pre>
+ *      final Images imgs = docker.imageS();//all listed images.
+ *      final Images filtered = imgs.filter(...);
+ *      final Images again = filtered.filter(...); //respects both filters.
+ *  </pre>
+ * @todo #144:30min Add the save() method, which will save the given Images,
+ *  an InputStream representing the created tarball will be created (see method
+ *  "Export several images" from the docs.
  */
 public interface Images extends Iterable<Image> {
 

--- a/src/main/java/com/amihaiemil/docker/ListedImages.java
+++ b/src/main/java/com/amihaiemil/docker/ListedImages.java
@@ -31,12 +31,16 @@ import java.net.URI;
 import java.util.Iterator;
 
 /**
- * These are some Images after applying a filter.
+ * Listed images, which may have a filter applied.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.3
+ * @todo #144:30min Finish implementation here, add a Map to this class, that
+ *  would hold the actual filters and apply them when making the call in the
+ *  iterator() method. Also, more ctors should be available, at least one with
+ *  filters and one without filters.
  */
-final class FilteredImages extends RtImages {
+final class ListedImages extends RtImages {
 
     /**
      * Ctor.
@@ -45,7 +49,7 @@ final class FilteredImages extends RtImages {
      * @param dkr The docker entry point.
      * @checkstyle ParameterNumber (10 lines)
      */
-    FilteredImages(final HttpClient client, final URI uri, final Docker dkr) {
+    ListedImages(final HttpClient client, final URI uri, final Docker dkr) {
         super(client, uri, dkr);
     }
 

--- a/src/main/java/com/amihaiemil/docker/RtDocker.java
+++ b/src/main/java/com/amihaiemil/docker/RtDocker.java
@@ -79,7 +79,7 @@ abstract class RtDocker implements Docker {
 
     @Override
     public final Images images() {
-        return new RtImages(
+        return new FilteredImages(
             this.client,
             URI.create(this.baseUri.toString() + "/images"),
             this

--- a/src/main/java/com/amihaiemil/docker/RtDocker.java
+++ b/src/main/java/com/amihaiemil/docker/RtDocker.java
@@ -79,7 +79,7 @@ abstract class RtDocker implements Docker {
 
     @Override
     public final Images images() {
-        return new FilteredImages(
+        return new ListedImages(
             this.client,
             URI.create(this.baseUri.toString() + "/images"),
             this

--- a/src/main/java/com/amihaiemil/docker/RtImages.java
+++ b/src/main/java/com/amihaiemil/docker/RtImages.java
@@ -28,10 +28,8 @@ package com.amihaiemil.docker;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
-import java.util.Iterator;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 
 import javax.json.Json;
@@ -42,14 +40,14 @@ import javax.json.Json;
  * @version $Id$
  * @since 0.0.1
  */
-final class RtImages implements Images {
+abstract class RtImages implements Images {
     /**
      * Apache HttpClient which sends the requests.
      */
     private final HttpClient client;
 
     /**
-     * Base URI.
+     * Base URI for Images API.
      */
     private final URI baseUri;
 
@@ -63,6 +61,7 @@ final class RtImages implements Images {
      * @param client The http client.
      * @param uri The URI for this Images API.
      * @param dkr The docker entry point.
+     * @checkstyle ParameterNumber (10 lines)
      */
     RtImages(final HttpClient client, final URI uri, final Docker dkr) {
         this.client = client;
@@ -124,24 +123,23 @@ final class RtImages implements Images {
     }
 
     @Override
-    public Iterator<Image> iterator() {
-        return new ResourcesIterator<>(
-            this.client,
-            new HttpGet(this.baseUri.toString().concat("/json")),
-            json-> new RtImage(
-                json,
-                this.client,
-                URI.create(
-                    this.baseUri.toString() + "/" + json.getString("Id")
-                ),
-                this.docker
-            )
-        );
-    }
-
-    @Override
     public Docker docker() {
         return this.docker;
     }
-    
+
+    /**
+     * Get the (protected) HttpClient for subclasses.
+     * @return HttpClient.
+     */
+    HttpClient client() {
+        return this.client;
+    }
+
+    /**
+     * Get the (protected) base URI for subclasses.
+     * @return URI.
+     */
+    URI baseUri() {
+        return this.baseUri;
+    }
 }

--- a/src/test/java/com/amihaiemil/docker/RtImagesTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImagesTestCase.java
@@ -57,7 +57,7 @@ public final class RtImagesTestCase {
     @Test
     public void iteratesImages() {
         final AtomicInteger count = new AtomicInteger();
-        new RtImages(
+        new FilteredImages(
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_OK,
@@ -87,7 +87,7 @@ public final class RtImagesTestCase {
     @Test
     public void iteratesZeroImages() throws Exception {
         final AtomicInteger count = new AtomicInteger();
-        new RtImages(
+        new FilteredImages(
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_OK,
@@ -109,7 +109,7 @@ public final class RtImagesTestCase {
      */
     @Test(expected = UnexpectedResponseException.class)
     public void iterateFailsIfResponseIs500() throws Exception {
-        new RtImages(
+        new FilteredImages(
             new AssertRequest(
                 new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             ),
@@ -127,7 +127,7 @@ public final class RtImagesTestCase {
      */
     @Test
     public void createSetsGivenParameters() throws Exception {
-        new RtImages(
+        new FilteredImages(
             new AssertRequest(
                 new Response(HttpStatus.SC_OK),
                 new Condition(
@@ -154,7 +154,7 @@ public final class RtImagesTestCase {
      */
     @Test(expected = UnexpectedResponseException.class)
     public void createErrorOnStatus404() throws Exception {
-        new RtImages(
+        new FilteredImages(
             new AssertRequest(
                 new Response(HttpStatus.SC_NOT_FOUND)
             ),
@@ -170,7 +170,7 @@ public final class RtImagesTestCase {
      */
     @Test(expected = UnexpectedResponseException.class)
     public void createErrorOnStatus500() throws Exception {
-        new RtImages(
+        new FilteredImages(
             new AssertRequest(
                 new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             ),
@@ -186,7 +186,7 @@ public final class RtImagesTestCase {
      */
     @Test
     public void prunesOk() throws Exception {
-        new RtImages(
+        new FilteredImages(
             new AssertRequest(
                 new Response(HttpStatus.SC_OK),
                 new Condition(
@@ -211,7 +211,7 @@ public final class RtImagesTestCase {
      */
     @Test(expected = UnexpectedResponseException.class)
     public void pruneThrowsErrorOnResponse500() throws Exception {
-        new RtImages(
+        new FilteredImages(
             new AssertRequest(
                 new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             ),
@@ -226,7 +226,7 @@ public final class RtImagesTestCase {
     @Test
     public void returnsDocker() {
         MatcherAssert.assertThat(
-            new RtImages(
+            new FilteredImages(
                 new AssertRequest(
                     new Response(
                         HttpStatus.SC_OK,

--- a/src/test/java/com/amihaiemil/docker/RtImagesTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImagesTestCase.java
@@ -57,7 +57,7 @@ public final class RtImagesTestCase {
     @Test
     public void iteratesImages() {
         final AtomicInteger count = new AtomicInteger();
-        new FilteredImages(
+        new ListedImages(
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_OK,
@@ -87,7 +87,7 @@ public final class RtImagesTestCase {
     @Test
     public void iteratesZeroImages() throws Exception {
         final AtomicInteger count = new AtomicInteger();
-        new FilteredImages(
+        new ListedImages(
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_OK,
@@ -109,7 +109,7 @@ public final class RtImagesTestCase {
      */
     @Test(expected = UnexpectedResponseException.class)
     public void iterateFailsIfResponseIs500() throws Exception {
-        new FilteredImages(
+        new ListedImages(
             new AssertRequest(
                 new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             ),
@@ -127,7 +127,7 @@ public final class RtImagesTestCase {
      */
     @Test
     public void createSetsGivenParameters() throws Exception {
-        new FilteredImages(
+        new ListedImages(
             new AssertRequest(
                 new Response(HttpStatus.SC_OK),
                 new Condition(
@@ -154,7 +154,7 @@ public final class RtImagesTestCase {
      */
     @Test(expected = UnexpectedResponseException.class)
     public void createErrorOnStatus404() throws Exception {
-        new FilteredImages(
+        new ListedImages(
             new AssertRequest(
                 new Response(HttpStatus.SC_NOT_FOUND)
             ),
@@ -170,7 +170,7 @@ public final class RtImagesTestCase {
      */
     @Test(expected = UnexpectedResponseException.class)
     public void createErrorOnStatus500() throws Exception {
-        new FilteredImages(
+        new ListedImages(
             new AssertRequest(
                 new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             ),
@@ -186,7 +186,7 @@ public final class RtImagesTestCase {
      */
     @Test
     public void prunesOk() throws Exception {
-        new FilteredImages(
+        new ListedImages(
             new AssertRequest(
                 new Response(HttpStatus.SC_OK),
                 new Condition(
@@ -211,7 +211,7 @@ public final class RtImagesTestCase {
      */
     @Test(expected = UnexpectedResponseException.class)
     public void pruneThrowsErrorOnResponse500() throws Exception {
-        new FilteredImages(
+        new ListedImages(
             new AssertRequest(
                 new Response(HttpStatus.SC_INTERNAL_SERVER_ERROR)
             ),
@@ -226,7 +226,7 @@ public final class RtImagesTestCase {
     @Test
     public void returnsDocker() {
         MatcherAssert.assertThat(
-            new FilteredImages(
+            new ListedImages(
                 new AssertRequest(
                     new Response(
                         HttpStatus.SC_OK,


### PR DESCRIPTION
PR for #144 

RtImages is abstract since we will have at least 2 implementations: ``ListedImages`` and ``SearchedImages``, which will be iterated differently (use a different HTTP endpont).

Left a few puzzles for continuing implementation in different areas. 