### PR TITLE
(#153) Images.filter()

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Images.java
+++ b/src/main/java/com/amihaiemil/docker/Images.java
@@ -28,6 +28,7 @@ package com.amihaiemil.docker;
 import java.io.IOException;
 import java.io.Reader;
 import java.net.URL;
+import java.util.Map;
 
 /**
  * Images API.
@@ -37,10 +38,6 @@ import java.net.URL;
  * @since 0.0.1
  * @todo #98:30min Continue implementing the rest of the operations for the
  *  Images interface. See the docs referenced above for more details.
- * @todo #144:30min Add the filter(Map<String, String>) method which will
- *  filter the given instance of Images. If filter() is called more times,
- *  all of the specified filters should amount and be applied to the last
- *  resulting Images instance.
  * @todo #152:30min Add Fake implementations of Images and Image, in order to
  *  unit test method save() and other future methods which may require more
  *  than 1 HTTP request. Currently, the unit testing infrastructure does
@@ -93,6 +90,14 @@ public interface Images extends Iterable<Image> {
      *  unexpected status.
      */
     Reader save() throws IOException, UnexpectedResponseException;
+
+    /**
+     * Filter these images.
+     * @param filters Filters to apply.
+     * @return Filtered images.
+     * @see <a href="https://docs.docker.com/engine/api/v1.35/#operation/ImageList">Docker API Docs</a>
+     */
+    Images filter(Map<String, Iterable<String>> filters);
 
     /**
      * Return the Docker engine where these Images came from.

--- a/src/main/java/com/amihaiemil/docker/ListedImages.java
+++ b/src/main/java/com/amihaiemil/docker/ListedImages.java
@@ -29,6 +29,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import java.net.URI;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import javax.json.Json;
@@ -105,6 +106,20 @@ final class ListedImages extends RtImages {
                 ),
                 super.docker()
             )
+        );
+    }
+
+    @Override
+    public Images filter(final Map<String, Iterable<String>> fltrs) {
+        final Map<String, Iterable<String>> merged = new HashMap<>(
+            this.filters
+        );
+        merged.putAll(fltrs);
+        return new ListedImages(
+            super.client(),
+            this.baseUri(),
+            this.docker(),
+            merged
         );
     }
 }

--- a/src/test/java/com/amihaiemil/docker/RtImagesITCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImagesITCase.java
@@ -35,6 +35,7 @@ import java.io.File;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
+ * @todo #153:30min Add integration tests for filters.
  */
 public final class RtImagesITCase {
 


### PR DESCRIPTION
This PR is for #153:
* Sketch of `Images.filter()` in `ListedImages`
* Left puzzle for implementing integration tests for `RtImages.filter()`

I'm also not so sure what the merge strategy should be for these filters. This PR will simply substitute any previously specified filter's values, but I'm not sure if you wanted to actually *merge* the values of the filters.