### PR TITLE
(#176) HttpClientEnvelope + PlainHttpClient

### DIFF
--- a/src/main/java/com/amihaiemil/docker/HttpClientEnvelope.java
+++ b/src/main/java/com/amihaiemil/docker/HttpClientEnvelope.java
@@ -42,6 +42,7 @@ import org.apache.http.protocol.HttpContext;
  * HTTP client envelope.
  *
  * @author George Aristy (george.aristy@gmail.com)
+ * @version $Id$
  * @since 0.0.4
  */
 abstract class HttpClientEnvelope implements HttpClient {

--- a/src/main/java/com/amihaiemil/docker/HttpClientEnvelope.java
+++ b/src/main/java/com/amihaiemil/docker/HttpClientEnvelope.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2018, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.amihaiemil.docker;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.params.HttpParams;
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * HTTP client envelope.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 0.0.4
+ */
+abstract class HttpClientEnvelope implements HttpClient {
+    /**
+     * Actual HttpClient.
+     */
+    private final HttpClient enveloped;
+
+    /**
+     * Ctor.
+     * @param enveloped The concrete http client
+     */
+    HttpClientEnvelope(final Supplier<HttpClient> enveloped) {
+        this.enveloped = enveloped.get();
+    }
+
+    @Override
+    public HttpParams getParams() {
+        return this.enveloped.getParams();
+    }
+  
+    @Override
+    public ClientConnectionManager getConnectionManager() {
+        return this.enveloped.getConnectionManager();
+    }
+  
+    @Override
+    public HttpResponse execute(final HttpUriRequest request)
+        throws IOException, ClientProtocolException {
+        return this.enveloped.execute(request);
+    }
+  
+    @Override
+    public HttpResponse execute(final HttpUriRequest request,
+        final HttpContext context)
+        throws IOException, ClientProtocolException {
+        return this.enveloped.execute(request, context);
+    }
+  
+    @Override
+    public HttpResponse execute(final HttpHost target,
+        final HttpRequest request)
+        throws IOException, ClientProtocolException {
+        return this.enveloped.execute(target, request);
+    }
+  
+    @Override
+    public HttpResponse execute(final HttpHost target,
+        final HttpRequest request, final HttpContext context)
+        throws IOException, ClientProtocolException {
+        return this.enveloped.execute(target, request, context);
+    }
+  
+    @Override
+    public <T> T execute(final HttpUriRequest request,
+        final ResponseHandler<? extends T> responseHandler)
+        throws IOException, ClientProtocolException {
+        return this.enveloped.execute(request, responseHandler);
+    }
+  
+    @Override
+    public <T> T execute(final HttpUriRequest request,
+        final ResponseHandler<? extends T> responseHandler,
+        final HttpContext context) throws IOException, ClientProtocolException {
+        return this.enveloped.execute(request, responseHandler, context);
+    }
+  
+    @Override
+    public <T> T execute(final HttpHost target, final HttpRequest request,
+        final ResponseHandler<? extends T> responseHandler)
+        throws IOException, ClientProtocolException {
+        return this.enveloped.execute(target, request, responseHandler);
+    }
+  
+    // @checkstyle ParameterNumber (2 lines)
+    @Override
+    public <T> T execute(final HttpHost target, final HttpRequest request,
+        final ResponseHandler<? extends T> responseHandler,
+        final HttpContext context) throws IOException, ClientProtocolException {
+        return this.enveloped.execute(
+            target, request, responseHandler, context
+        );
+    }
+}

--- a/src/main/java/com/amihaiemil/docker/PlainHttpClient.java
+++ b/src/main/java/com/amihaiemil/docker/PlainHttpClient.java
@@ -31,6 +31,7 @@ import org.apache.http.impl.client.HttpClients;
  * Plain HTTP (no TLS) client.
  *
  * @author George Aristy (george.aristy@gmail.com)
+ * @version $Id$
  * @since 0.0.4
  */
 final class PlainHttpClient extends HttpClientEnvelope {

--- a/src/main/java/com/amihaiemil/docker/PlainHttpClient.java
+++ b/src/main/java/com/amihaiemil/docker/PlainHttpClient.java
@@ -25,56 +25,23 @@
  */
 package com.amihaiemil.docker;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.security.GeneralSecurityException;
-import java.util.function.Supplier;
-
-import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.ssl.SSLContexts;
 
 /**
- * An HttpClient that works over a normal network socket.
+ * Plain HTTP (no TLS) client.
  *
  * @author George Aristy (george.aristy@gmail.com)
- * @version $Id$
- * @since 0.0.1
- * @checkstyle ParameterNumber (150 lines)
+ * @since 0.0.4
  */
-final class SslHttpClient extends HttpClientEnvelope {
+final class PlainHttpClient extends HttpClientEnvelope {
     /**
      * Ctor.
-     * @param keys Path to the keystore.
-     * @param trust Path to the truststore.
-     * @param storePwd Password for the keystore.
-     * @param keyPwd Passphrase for the key.
      */
-    SslHttpClient(
-        final Path keys, final Path trust,
-        final char[] storePwd, final char[] keyPwd) {
-        this(() -> {
-            try {
-                return HttpClients.custom()
-                    .setMaxConnPerRoute(10)
-                    .setMaxConnTotal(10)
-                    .setSSLContext(
-                        SSLContexts.custom()
-                            .loadTrustMaterial(trust.toFile())
-                            .loadKeyMaterial(keys.toFile(), storePwd, keyPwd)
-                            .build()
-                    ).build();
-            } catch (final IOException | GeneralSecurityException ex) {
-                throw new IllegalStateException(ex);
-            }
-        });
-    }
-
-    /**
-     * Ctor.
-     * @param client Decorated HttpClient.
-     */
-    SslHttpClient(final Supplier<HttpClient> client) {
-        super(client);
+    PlainHttpClient() {
+        super(() -> HttpClients.custom()
+            .setMaxConnPerRoute(10)
+            .setMaxConnTotal(10)
+            .build()
+        );
     }
 }

--- a/src/main/java/com/amihaiemil/docker/RemoteDocker.java
+++ b/src/main/java/com/amihaiemil/docker/RemoteDocker.java
@@ -77,6 +77,17 @@ public final class RemoteDocker extends RtDocker {
     }
 
     /**
+     * Remote Docker engine.
+     * 
+     * An insecure docker API v1.35 endpoint is assumed.
+     * 
+     * @param uri Remote Docker URI.
+     */
+    public RemoteDocker(final URI uri) {
+        this(new PlainHttpClient(), uri);
+    }
+
+    /**
      * Remote Docker engine. You have to configure your own HttpClient,
      * most likely with some authentication mechanism, depending on where
      * the Docker engine is on the Network. <br><br>

--- a/src/main/java/com/amihaiemil/docker/UnixHttpClient.java
+++ b/src/main/java/com/amihaiemil/docker/UnixHttpClient.java
@@ -25,20 +25,11 @@
  */
 package com.amihaiemil.docker;
 
-import org.apache.http.HttpHost;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.ResponseHandler;
-import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.config.RegistryBuilder;
-import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.params.HttpParams;
-import org.apache.http.protocol.HttpContext;
 import java.io.File;
-import java.io.IOException;
 import java.util.function.Supplier;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 
@@ -51,13 +42,7 @@ import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
  * @checkstyle ParameterNumber (150 lines)
  * @checkstyle AnonInnerLength (150 lines)
  */
-final class UnixHttpClient implements HttpClient {
-
-    /**
-     * Decorated HttpClient.
-     */
-    private HttpClient client;
-
+final class UnixHttpClient extends HttpClientEnvelope {
     /**
      * Ctor.
      * @param socketFile Unix socket on disk.
@@ -81,97 +66,9 @@ final class UnixHttpClient implements HttpClient {
 
     /**
      * Ctor.
-     * @param client The HttpClient.
+     * @param client The http client
      */
     UnixHttpClient(final Supplier<HttpClient> client) {
-        this(client.get());
-    }
-
-    /**
-     * Ctor.
-     * @param client Decorated HttpClient.
-     */
-    UnixHttpClient(final HttpClient client) {
-        this.client = client;
-    }
-
-    @Override
-    public HttpParams getParams() {
-        return this.client.getParams();
-    }
-
-    @Override
-    public ClientConnectionManager getConnectionManager() {
-        return this.client.getConnectionManager();
-    }
-
-    @Override
-    public HttpResponse execute(
-        final HttpUriRequest httpUriRequest
-    ) throws IOException {
-        return this.client.execute(httpUriRequest);
-    }
-
-    @Override
-    public HttpResponse execute(
-        final HttpUriRequest httpUriRequest, final HttpContext httpContext
-    ) throws IOException {
-        return this.client.execute(httpUriRequest, httpContext);
-    }
-
-    @Override
-    public HttpResponse execute(
-        final HttpHost httpHost, final HttpRequest httpRequest
-    ) throws IOException {
-        return this.client.execute(httpHost, httpRequest);
-    }
-
-    @Override
-    public HttpResponse execute(
-        final HttpHost httpHost,
-        final HttpRequest httpRequest,
-        final HttpContext httpContext
-    ) throws IOException {
-        return this.client.execute(httpHost, httpRequest, httpContext);
-    }
-
-    @Override
-    public <T> T execute(
-        final HttpUriRequest httpUriRequest,
-        final ResponseHandler<? extends T> responseHandler
-    ) throws IOException {
-        return this.client.execute(httpUriRequest, responseHandler);
-    }
-
-    @Override
-    public <T> T execute(
-        final HttpUriRequest httpUriRequest,
-        final ResponseHandler<? extends T> responseHandler,
-        final HttpContext httpContext
-    ) throws IOException {
-        return this.client.execute(
-            httpUriRequest, responseHandler, httpContext
-        );
-    }
-
-    @Override
-    public <T> T execute(
-        final HttpHost httpHost,
-        final HttpRequest httpRequest,
-        final ResponseHandler<? extends T> responseHandler
-    ) throws IOException {
-        return this.client.execute(httpHost, httpRequest, responseHandler);
-    }
-
-    @Override
-    public <T> T execute(
-        final HttpHost httpHost,
-        final HttpRequest httpRequest,
-        final ResponseHandler<? extends T> responseHandler,
-        final HttpContext httpContext
-    ) throws IOException {
-        return this.client.execute(
-            httpHost, httpRequest, responseHandler, httpContext
-        );
+        super(client);
     }
 }

--- a/src/test/java/com/amihaiemil/docker/SslHttpClientTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/SslHttpClientTestCase.java
@@ -52,7 +52,7 @@ public final class SslHttpClientTestCase {
         final Response response = new Response(HttpStatus.SC_OK, "");
         MatcherAssert.assertThat(
             new SslHttpClient(
-                new AssertRequest(response)
+                () -> new AssertRequest(response)
             ).execute(new HttpGet()),
             Matchers.is(response)
         );

--- a/src/test/java/com/amihaiemil/docker/UnixHttpClientTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/UnixHttpClientTestCase.java
@@ -70,7 +70,7 @@ public final class UnixHttpClientTestCase {
         final HttpClient decorated = Mockito.mock(HttpClient.class);
         Mockito.when(decorated.getParams()).thenReturn(params);
 
-        final HttpClient unix = new UnixHttpClient(decorated);
+        final HttpClient unix = new UnixHttpClient(() -> decorated);
         MatcherAssert.assertThat(unix.getParams(), Matchers.is(params));
         Mockito.verify(
             decorated, Mockito.times(1)
@@ -88,7 +88,7 @@ public final class UnixHttpClientTestCase {
         final HttpClient decorated = Mockito.mock(HttpClient.class);
         Mockito.when(decorated.getConnectionManager()).thenReturn(cmngr);
 
-        final HttpClient unix = new UnixHttpClient(decorated);
+        final HttpClient unix = new UnixHttpClient(() -> decorated);
         MatcherAssert.assertThat(
             unix.getConnectionManager(), Matchers.is(cmngr)
         );
@@ -108,7 +108,7 @@ public final class UnixHttpClientTestCase {
         final HttpClient decorated = Mockito.mock(HttpClient.class);
         Mockito.when(decorated.execute(req)).thenReturn(resp);
 
-        final HttpClient unix = new UnixHttpClient(decorated);
+        final HttpClient unix = new UnixHttpClient(() -> decorated);
         MatcherAssert.assertThat(
             unix.execute(req), Matchers.is(resp)
         );
@@ -132,7 +132,7 @@ public final class UnixHttpClientTestCase {
             decorated.execute(req, context)
         ).thenReturn(resp);
 
-        final HttpClient unix = new UnixHttpClient(decorated);
+        final HttpClient unix = new UnixHttpClient(() -> decorated);
         MatcherAssert.assertThat(
             unix.execute(req, context), Matchers.is(resp)
         );
@@ -155,7 +155,7 @@ public final class UnixHttpClientTestCase {
             decorated.execute(host, req)
         ).thenReturn(resp);
 
-        final HttpClient unix = new UnixHttpClient(decorated);
+        final HttpClient unix = new UnixHttpClient(() -> decorated);
         MatcherAssert.assertThat(
             unix.execute(host, req), Matchers.is(resp)
         );
@@ -180,7 +180,7 @@ public final class UnixHttpClientTestCase {
                 decorated.execute(host, req, context)
         ).thenReturn(resp);
 
-        final HttpClient unix = new UnixHttpClient(decorated);
+        final HttpClient unix = new UnixHttpClient(() -> decorated);
         MatcherAssert.assertThat(
             unix.execute(host, req, context), Matchers.is(resp)
         );
@@ -205,7 +205,7 @@ public final class UnixHttpClientTestCase {
             decorated.execute(req, handler)
         ).thenReturn("executed");
 
-        final HttpClient unix = new UnixHttpClient(decorated);
+        final HttpClient unix = new UnixHttpClient(() -> decorated);
         MatcherAssert.assertThat(
             unix.execute(req, handler), Matchers.equalTo("executed")
         );
@@ -231,7 +231,7 @@ public final class UnixHttpClientTestCase {
             decorated.execute(req, handler, context)
         ).thenReturn("executed");
 
-        final HttpClient unix = new UnixHttpClient(decorated);
+        final HttpClient unix = new UnixHttpClient(() -> decorated);
         MatcherAssert.assertThat(
             unix.execute(req, handler, context), Matchers.equalTo("executed")
         );
@@ -258,7 +258,7 @@ public final class UnixHttpClientTestCase {
             decorated.execute(host, req, handler)
         ).thenReturn("executed");
 
-        final HttpClient unix = new UnixHttpClient(decorated);
+        final HttpClient unix = new UnixHttpClient(() -> decorated);
         MatcherAssert.assertThat(
             unix.execute(host, req, handler), Matchers.equalTo("executed")
         );
@@ -285,7 +285,7 @@ public final class UnixHttpClientTestCase {
             decorated.execute(host, req, handler, context)
         ).thenReturn("executed");
 
-        final HttpClient unix = new UnixHttpClient(decorated);
+        final HttpClient unix = new UnixHttpClient(() -> decorated);
         MatcherAssert.assertThat(
             unix.execute(host, req, handler, context),
             Matchers.equalTo("executed")


### PR DESCRIPTION
This PR is for #176:
* Added `HttpClientEnvelope`
* Refactored existing http clients to extend `HttpClientEnvelope`
* Added `PlainHttpClient`
* Added ctor for `RemoteDocker` that defaults to the `PlainHttpClient`