### PR TITLE
For #254: Implementing Images.importFromTar method

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Images.java
+++ b/src/main/java/com/amihaiemil/docker/Images.java
@@ -44,9 +44,9 @@ import java.util.Map;
  *  that this method is implemented using Docker API Image Create method.
  *  See https://docs.docker.com/engine/api/v1.35/#operation/ImageCreate for more
  *  details.
- * @todo #254:30mim ImportFromTar method should return Image instead of void. Find a way to
- *  read the imported Image's identifier, maybe add a new implementation of Image for this
- *  case.
+ * @todo #254:30mim ImportFromTar method should return Image instead of void.
+ *  Find a way to read the imported Image's identifier, maybe add a new
+ *  implementation of Image for this case.
  */
 public interface Images extends Iterable<Image> {
 

--- a/src/main/java/com/amihaiemil/docker/Images.java
+++ b/src/main/java/com/amihaiemil/docker/Images.java
@@ -27,6 +27,7 @@ package com.amihaiemil.docker;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.net.URL;
 import java.util.Map;
 
 /**
@@ -39,6 +40,11 @@ import java.util.Map;
  *  unit test method save() and other future methods which may require more
  *  than 1 HTTP request. Currently, the unit testing infrastructure does
  *  not support more than 1 HTTP request..
+ * @todo #254:30min Implement importImage method and create tests. Please note
+ *  that this method is implemented using Docker API Image Create method.
+ *  See https://docs.docker.com/engine/api/v1.35/#operation/ImageCreate for more
+ *  details.
+ * @todo #254:30mim ImportFromTar method should return Image instead of void.
  */
 public interface Images extends Iterable<Image> {
 
@@ -54,6 +60,20 @@ public interface Images extends Iterable<Image> {
      */
     Image pull(
         final String name, final String tag
+    ) throws IOException, UnexpectedResponseException;
+
+    /**
+     * Import an Image.
+     * @param source The URL from which the image can be retrieved.
+     * @param repo Repository name given to an image when it is imported.
+     *   The repo may include a tag.
+     * @return The imported Image.
+     * @throws IOException If an I/O error occurs.
+     * @throws UnexpectedResponseException If the API responds with an
+     *  undexpected status.
+     */
+    Image importImage(
+        final URL source, final String repo
     ) throws IOException, UnexpectedResponseException;
 
     /**

--- a/src/main/java/com/amihaiemil/docker/Images.java
+++ b/src/main/java/com/amihaiemil/docker/Images.java
@@ -44,7 +44,9 @@ import java.util.Map;
  *  that this method is implemented using Docker API Image Create method.
  *  See https://docs.docker.com/engine/api/v1.35/#operation/ImageCreate for more
  *  details.
- * @todo #254:30mim ImportFromTar method should return Image instead of void.
+ * @todo #254:30mim ImportFromTar method should return Image instead of void. Find a way to
+ *  read the imported Image's identifier, maybe add a new implementation of Image for this
+ *  case.
  */
 public interface Images extends Iterable<Image> {
 

--- a/src/main/java/com/amihaiemil/docker/Images.java
+++ b/src/main/java/com/amihaiemil/docker/Images.java
@@ -27,7 +27,6 @@ package com.amihaiemil.docker;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.net.URL;
 import java.util.Map;
 
 /**
@@ -36,9 +35,6 @@ import java.util.Map;
  * @version $Id$
  * @see <a href="https://docs.docker.com/engine/api/v1.35/#tag/Image">Docker Images API</a>
  * @since 0.0.1
- * @todo #170:30min Continue implementing the rest of the operations for the
- *  Images interface. Already made the tests for import an image in
- *  RtImagesTestCase. See the docs referenced above for more details.
  * @todo #152:30min Add Fake implementations of Images and Image, in order to
  *  unit test method save() and other future methods which may require more
  *  than 1 HTTP request. Currently, the unit testing infrastructure does
@@ -61,18 +57,15 @@ public interface Images extends Iterable<Image> {
     ) throws IOException, UnexpectedResponseException;
 
     /**
-     * Import an Image.
-     * @param source The URL from which the image can be retrieved.
-     * @param repo Repository name given to an image when it is imported.
-     *   The repo may include a tag.
-     * @return The imported Image.
+     * Import images from tar file.
+     *
+     * @param file Path to Tar file containing Images.
      * @throws IOException If an I/O error occurs.
      * @throws UnexpectedResponseException If the API responds with an
-     *  undexpected status.
+     *  unexpected status.
      */
-    Image importImage(
-        final URL source, final String repo
-    ) throws IOException, UnexpectedResponseException;
+    void importFromTar(
+        String file) throws IOException, UnexpectedResponseException;
 
     /**
      * Deletes unused images.

--- a/src/main/java/com/amihaiemil/docker/RtImages.java
+++ b/src/main/java/com/amihaiemil/docker/RtImages.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URI;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.StringJoiner;
@@ -102,6 +103,18 @@ abstract class RtImages implements Images {
         } finally {
             create.releaseConnection();
         }
+    }
+
+    @Override
+    public Image importImage(
+        final URL source, final String repo
+    ) throws IOException, UnexpectedResponseException {
+        throw new UnsupportedOperationException(
+            String.join(" ",
+                "Not yet implemented. If you can contribute please,",
+                "do it here: https://www.github.com/amihaiemil/docker-java-api"
+            )
+        );
     }
 
     @Override

--- a/src/test/java/com/amihaiemil/docker/RtImagesTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImagesTestCase.java
@@ -28,20 +28,17 @@ package com.amihaiemil.docker;
 import com.amihaiemil.docker.mock.AssertRequest;
 import com.amihaiemil.docker.mock.Condition;
 import com.amihaiemil.docker.mock.Response;
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.json.Json;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpStatus;
 import org.apache.http.util.EntityUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import javax.json.Json;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URL;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Unit tests for {@link RtImages}.
@@ -247,12 +244,11 @@ public final class RtImagesTestCase {
     }
 
     /**
-     * RtImages can import images successfully.
+     * RtImages can import images from tar successfully.
      * @throws Exception If something goes wrong
      */
     @Test
-    @Ignore
-    public void importImage() throws Exception{
+    public void importFromTar() throws Exception{
         new ListedImages(
             new AssertRequest(
                 new Response(HttpStatus.SC_OK),
@@ -282,8 +278,9 @@ public final class RtImagesTestCase {
                     }
                 )
             ),
-            URI.create("http://localhost"),
+            URI.create("http://localhost/images"),
             DOCKER
-        ).importImage(new URL("http://localhost/images"), "docker-java-api");
+            ).importFromTar(
+                this.getClass().getResource("/images.tar.txt").getFile());
     }
 }

--- a/src/test/resources/images.tar.txt
+++ b/src/test/resources/images.tar.txt
@@ -1,0 +1,1 @@
+This is a dummy text file pretending to be tar. Used for unit tests only.


### PR DESCRIPTION
For #254:

- Renaming importImages to importFromTar (because of the Docker documentation:
  https://docs.docker.com/engine/api/v1.35/#operation/ImageLoad
- Implementing Images.importFromTar method