### PR TITLE
For #275: Updating Copyright headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018, Mihai A.
+Copyright (c) 2018-2019, Mihai A.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/amihaiemil/docker/Auth.java
+++ b/src/main/java/com/amihaiemil/docker/Auth.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/AuthHttpClient.java
+++ b/src/main/java/com/amihaiemil/docker/AuthHttpClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Container.java
+++ b/src/main/java/com/amihaiemil/docker/Container.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Containers.java
+++ b/src/main/java/com/amihaiemil/docker/Containers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Credentials.java
+++ b/src/main/java/com/amihaiemil/docker/Credentials.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/DiskSpaceInfo.java
+++ b/src/main/java/com/amihaiemil/docker/DiskSpaceInfo.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.amihaiemil.docker;
 
 import javax.json.JsonObject;

--- a/src/main/java/com/amihaiemil/docker/Docker.java
+++ b/src/main/java/com/amihaiemil/docker/Docker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/DockerSystem.java
+++ b/src/main/java/com/amihaiemil/docker/DockerSystem.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.amihaiemil.docker;
 
 import java.io.IOException;

--- a/src/main/java/com/amihaiemil/docker/Exec.java
+++ b/src/main/java/com/amihaiemil/docker/Exec.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/FilteredUriBuilder.java
+++ b/src/main/java/com/amihaiemil/docker/FilteredUriBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/HttpClientEnvelope.java
+++ b/src/main/java/com/amihaiemil/docker/HttpClientEnvelope.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/IdentityToken.java
+++ b/src/main/java/com/amihaiemil/docker/IdentityToken.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Image.java
+++ b/src/main/java/com/amihaiemil/docker/Image.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Images.java
+++ b/src/main/java/com/amihaiemil/docker/Images.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Inspection.java
+++ b/src/main/java/com/amihaiemil/docker/Inspection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/JsonResource.java
+++ b/src/main/java/com/amihaiemil/docker/JsonResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/ListedImages.java
+++ b/src/main/java/com/amihaiemil/docker/ListedImages.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/ListedNetworks.java
+++ b/src/main/java/com/amihaiemil/docker/ListedNetworks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/ListedPlugins.java
+++ b/src/main/java/com/amihaiemil/docker/ListedPlugins.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/ListedVolumes.java
+++ b/src/main/java/com/amihaiemil/docker/ListedVolumes.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/LocalDocker.java
+++ b/src/main/java/com/amihaiemil/docker/LocalDocker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Logs.java
+++ b/src/main/java/com/amihaiemil/docker/Logs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/MatchStatus.java
+++ b/src/main/java/com/amihaiemil/docker/MatchStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Merged.java
+++ b/src/main/java/com/amihaiemil/docker/Merged.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Network.java
+++ b/src/main/java/com/amihaiemil/docker/Network.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Networks.java
+++ b/src/main/java/com/amihaiemil/docker/Networks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/PayloadOf.java
+++ b/src/main/java/com/amihaiemil/docker/PayloadOf.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/PlainHttpClient.java
+++ b/src/main/java/com/amihaiemil/docker/PlainHttpClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Plugin.java
+++ b/src/main/java/com/amihaiemil/docker/Plugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/PluginPrivilege.java
+++ b/src/main/java/com/amihaiemil/docker/PluginPrivilege.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Plugins.java
+++ b/src/main/java/com/amihaiemil/docker/Plugins.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/ReadJsonArray.java
+++ b/src/main/java/com/amihaiemil/docker/ReadJsonArray.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/ReadJsonObject.java
+++ b/src/main/java/com/amihaiemil/docker/ReadJsonObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/ReadStream.java
+++ b/src/main/java/com/amihaiemil/docker/ReadStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/ReadString.java
+++ b/src/main/java/com/amihaiemil/docker/ReadString.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/RegistryConfigAuth.java
+++ b/src/main/java/com/amihaiemil/docker/RegistryConfigAuth.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.amihaiemil.docker;
 
 import java.net.URI;

--- a/src/main/java/com/amihaiemil/docker/RemoteDocker.java
+++ b/src/main/java/com/amihaiemil/docker/RemoteDocker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/ResourcesIterator.java
+++ b/src/main/java/com/amihaiemil/docker/ResourcesIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/RtContainer.java
+++ b/src/main/java/com/amihaiemil/docker/RtContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/RtContainers.java
+++ b/src/main/java/com/amihaiemil/docker/RtContainers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/RtDocker.java
+++ b/src/main/java/com/amihaiemil/docker/RtDocker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/RtDockerSystem.java
+++ b/src/main/java/com/amihaiemil/docker/RtDockerSystem.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.amihaiemil.docker;
 
 import org.apache.http.HttpStatus;

--- a/src/main/java/com/amihaiemil/docker/RtImage.java
+++ b/src/main/java/com/amihaiemil/docker/RtImage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/RtImages.java
+++ b/src/main/java/com/amihaiemil/docker/RtImages.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/RtLogs.java
+++ b/src/main/java/com/amihaiemil/docker/RtLogs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/RtNetwork.java
+++ b/src/main/java/com/amihaiemil/docker/RtNetwork.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/RtNetworks.java
+++ b/src/main/java/com/amihaiemil/docker/RtNetworks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/RtPlugin.java
+++ b/src/main/java/com/amihaiemil/docker/RtPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/RtPlugins.java
+++ b/src/main/java/com/amihaiemil/docker/RtPlugins.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.amihaiemil.docker;
 
 import java.io.IOException;

--- a/src/main/java/com/amihaiemil/docker/RtSwarm.java
+++ b/src/main/java/com/amihaiemil/docker/RtSwarm.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/RtVolume.java
+++ b/src/main/java/com/amihaiemil/docker/RtVolume.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.amihaiemil.docker;
 
 import java.io.IOException;

--- a/src/main/java/com/amihaiemil/docker/RtVolumes.java
+++ b/src/main/java/com/amihaiemil/docker/RtVolumes.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/SslHttpClient.java
+++ b/src/main/java/com/amihaiemil/docker/SslHttpClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Swarm.java
+++ b/src/main/java/com/amihaiemil/docker/Swarm.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/SystemDiskSpaceInfo.java
+++ b/src/main/java/com/amihaiemil/docker/SystemDiskSpaceInfo.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.amihaiemil.docker;
 
 import javax.json.JsonArray;

--- a/src/main/java/com/amihaiemil/docker/UncheckedUriBuilder.java
+++ b/src/main/java/com/amihaiemil/docker/UncheckedUriBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/UnexpectedResponseException.java
+++ b/src/main/java/com/amihaiemil/docker/UnexpectedResponseException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/UnixHttpClient.java
+++ b/src/main/java/com/amihaiemil/docker/UnixHttpClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/UnixSocketFactory.java
+++ b/src/main/java/com/amihaiemil/docker/UnixSocketFactory.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.amihaiemil.docker;
 
 import java.io.File;

--- a/src/main/java/com/amihaiemil/docker/UserAgentRequestHeader.java
+++ b/src/main/java/com/amihaiemil/docker/UserAgentRequestHeader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Volume.java
+++ b/src/main/java/com/amihaiemil/docker/Volume.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/com/amihaiemil/docker/Volumes.java
+++ b/src/main/java/com/amihaiemil/docker/Volumes.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/AuthHttpClientTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/AuthHttpClientTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/CredentialsTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/CredentialsTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/FilteredUriBuilderTest.java
+++ b/src/test/java/com/amihaiemil/docker/FilteredUriBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/IdentityTokenTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/IdentityTokenTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/InspectionTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/InspectionTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/ListedImagesTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/ListedImagesTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/ListedNetworksTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/ListedNetworksTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/ListedPluginsTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/ListedPluginsTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/ListedVolumesTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/ListedVolumesTestCase.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.amihaiemil.docker;
 
 import com.amihaiemil.docker.mock.AssertRequest;

--- a/src/test/java/com/amihaiemil/docker/LocalDockerITCase.java
+++ b/src/test/java/com/amihaiemil/docker/LocalDockerITCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/LocalDockerTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/LocalDockerTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/MatchStatusTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/MatchStatusTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/MergedTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/MergedTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/ReadJsonArrayTest.java
+++ b/src/test/java/com/amihaiemil/docker/ReadJsonArrayTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RegistryConfigAuthTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RegistryConfigAuthTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RemoteDockerTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RemoteDockerTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtContainerITCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtContainerITCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtContainerTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtContainerTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtContainersITCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtContainersITCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtContainersTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtContainersTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtDockerSystemITCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtDockerSystemITCase.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.amihaiemil.docker;
 
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/com/amihaiemil/docker/RtDockerSystemTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtDockerSystemTestCase.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.amihaiemil.docker;
 
 import com.amihaiemil.docker.mock.AssertRequest;

--- a/src/test/java/com/amihaiemil/docker/RtImageITCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImageITCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtImageTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImageTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtImagesITCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImagesITCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtImagesTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtImagesTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtLogsTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtLogsTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtNetworkTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtNetworkTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtNetworksTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtNetworksTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtPluginTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtPluginTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtPluginsTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtPluginsTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtSwarmTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtSwarmTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/RtVolumeTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtVolumeTestCase.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.amihaiemil.docker;
 
 import com.amihaiemil.docker.mock.AssertRequest;

--- a/src/test/java/com/amihaiemil/docker/RtVolumesTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/RtVolumesTestCase.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.amihaiemil.docker;
 
 import com.amihaiemil.docker.mock.AssertRequest;

--- a/src/test/java/com/amihaiemil/docker/SslHttpClientTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/SslHttpClientTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/UnexpectedResponseExceptionTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/UnexpectedResponseExceptionTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/UnixHttpClientITCase.java
+++ b/src/test/java/com/amihaiemil/docker/UnixHttpClientITCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/UnixHttpClientTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/UnixHttpClientTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/UserAgentRequestHeaderTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/UserAgentRequestHeaderTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/mock/AssertRequest.java
+++ b/src/test/java/com/amihaiemil/docker/mock/AssertRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/mock/AssertRequestTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/mock/AssertRequestTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/mock/Condition.java
+++ b/src/test/java/com/amihaiemil/docker/mock/Condition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/mock/Response.java
+++ b/src/test/java/com/amihaiemil/docker/mock/Response.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/mock/ResponseTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/mock/ResponseTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/com/amihaiemil/docker/mock/UnixServer.java
+++ b/src/test/java/com/amihaiemil/docker/mock/UnixServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, Mihai Emil Andronache
+ * Copyright (c) 2018-2019, Mihai Emil Andronache
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
For #275:

- Updating Copyright header's year, from `2018` to `2018-2019`.
- Adding Copyright headers to some files that didn't have it.