### PR TITLE
For #276: Removing puzzle for importImage

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Images.java
+++ b/src/main/java/com/amihaiemil/docker/Images.java
@@ -40,10 +40,6 @@ import java.util.Map;
  *  unit test method save() and other future methods which may require more
  *  than 1 HTTP request. Currently, the unit testing infrastructure does
  *  not support more than 1 HTTP request..
- * @todo #254:30min Implement importImage method and create tests. Please note
- *  that this method is implemented using Docker API Image Create method.
- *  See https://docs.docker.com/engine/api/v1.35/#operation/ImageCreate for more
- *  details.
  * @todo #254:30mim ImportFromTar method should return Image instead of void.
  *  Find a way to read the imported Image's identifier, maybe add a new
  *  implementation of Image for this case.


### PR DESCRIPTION
For #276:

- Removing puzzle for implementing `importImage` method.