### PR TITLE
Images.importFromTar() :: Images

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Images.java
+++ b/src/main/java/com/amihaiemil/docker/Images.java
@@ -78,11 +78,12 @@ public interface Images extends Iterable<Image> {
      * Import images from tar file.
      *
      * @param file Path to Tar file containing Images.
+     * @return Images All images, including the newly imported ones.
      * @throws IOException If an I/O error occurs.
      * @throws UnexpectedResponseException If the API responds with an
      *  unexpected status.
      */
-    void importFromTar(
+    Images importFromTar(
         String file) throws IOException, UnexpectedResponseException;
 
     /**

--- a/src/main/java/com/amihaiemil/docker/Images.java
+++ b/src/main/java/com/amihaiemil/docker/Images.java
@@ -40,9 +40,6 @@ import java.util.Map;
  *  unit test method save() and other future methods which may require more
  *  than 1 HTTP request. Currently, the unit testing infrastructure does
  *  not support more than 1 HTTP request..
- * @todo #254:30mim ImportFromTar method should return Image instead of void.
- *  Find a way to read the imported Image's identifier, maybe add a new
- *  implementation of Image for this case.
  */
 public interface Images extends Iterable<Image> {
 

--- a/src/main/java/com/amihaiemil/docker/RtImages.java
+++ b/src/main/java/com/amihaiemil/docker/RtImages.java
@@ -134,7 +134,7 @@ abstract class RtImages implements Images {
     }
 
     @Override
-    public void importFromTar(
+    public Images importFromTar(
         final String file) throws IOException, UnexpectedResponseException {
         final HttpPost load  = new HttpPost(
             new UncheckedUriBuilder(this.baseUri.toString().concat("/load"))
@@ -156,6 +156,7 @@ abstract class RtImages implements Images {
         } finally {
             load.releaseConnection();
         }
+        return this;
     }
 
     @Override

--- a/src/test/resources/placeholder.md
+++ b/src/test/resources/placeholder.md
@@ -1,1 +1,0 @@
-placeholder for src/test/resources


### PR DESCRIPTION
PR for #277 
The method is now returning ``this``, since ``Images`` will always iterate over the existing images (this means also the newly imported ones will be iterated). 