### PR TITLE
#252 Fixing LocalDockerITCase for iterating volumes.

### DIFF
--- a/src/main/java/com/amihaiemil/docker/ListedVolumes.java
+++ b/src/main/java/com/amihaiemil/docker/ListedVolumes.java
@@ -80,13 +80,12 @@ final class ListedVolumes extends RtVolumes {
         );
         final HttpGet get = new HttpGet(uri.build());
         try {
-            final JsonObject obj = super.client().execute(
+            return super.client().execute(
                 get,
                 new ReadJsonObject(
                     new MatchStatus(get.getURI(), HttpStatus.SC_OK)
                 )
-            );
-            return obj.getJsonArray("Volumes").stream()
+            ).getJsonArray("Volumes").stream()
                 .map(json -> (JsonObject) json)
                 .map(
                     volume -> (Volume) new RtVolume(

--- a/src/main/java/com/amihaiemil/docker/ListedVolumes.java
+++ b/src/main/java/com/amihaiemil/docker/ListedVolumes.java
@@ -25,10 +25,14 @@
  */
 package com.amihaiemil.docker;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.stream.Collectors;
+import javax.json.JsonObject;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 
@@ -74,22 +78,36 @@ final class ListedVolumes extends RtVolumes {
         final FilteredUriBuilder uri = new FilteredUriBuilder(
             new UncheckedUriBuilder(super.baseUri().toString()), this.filters
         );
-        return new ResourcesIterator<>(
-            super.client(),
-            new HttpGet(
-                uri.build()
-            ),
-            volume -> new RtVolume(
-                volume,
-                super.client(),
-                URI.create(
-                    String.format("%s/%s",
-                        super.baseUri().toString(),
-                        volume.getString("Name")
+        final HttpGet get = new HttpGet(uri.build());
+        try {
+            final JsonObject obj = super.client().execute(
+                get,
+                new ReadJsonObject(
+                    new MatchStatus(get.getURI(), HttpStatus.SC_OK)
+                )
+            );
+            return obj.getJsonArray("Volumes").stream()
+                .map(json -> (JsonObject) json)
+                .map(
+                    volume -> (Volume) new RtVolume(
+                        volume,
+                        super.client(),
+                        URI.create(
+                            String.format("%s/%s",
+                                super.baseUri().toString(),
+                                volume.getString("Name")
+                            )
+                        ),
+                        super.docker()
                     )
-                ),
-                super.docker()
-            )
-        );
+                ).collect(Collectors.toList())
+                .iterator();
+        } catch (final IOException err) {
+            throw new RuntimeException(
+                String.format("Error executing GET on %s", super.baseUri())
+            );
+        } finally {
+            get.releaseConnection();
+        }
     }
 }

--- a/src/test/java/com/amihaiemil/docker/ListedVolumesTestCase.java
+++ b/src/test/java/com/amihaiemil/docker/ListedVolumesTestCase.java
@@ -59,7 +59,7 @@ public final class ListedVolumesTestCase {
             new AssertRequest(
                 new Response(
                     HttpStatus.SC_OK,
-                    "[{\"Name\": \"abc1\"}, {\"Name\":\"cde2\"}]"
+                    "{\"Volumes\":[{\"Name\": \"abc1\"}, {\"Name\":\"cde2\"}]}"
                 ),
                 new Condition(
                     "iterate() must send a GET request",
@@ -105,7 +105,7 @@ public final class ListedVolumesTestCase {
                 new Response(
                     HttpStatus.SC_OK,
                     //@checkstyle LineLength (1 line)
-                    "[{\"Name\": \"abc1\"}, {\"Name\": \"def2\"}, {\"Name\": \"ghi3\"}, {\"Name\":\"jkl4\"}]"
+                    "{\"Volumes\":[{\"Name\": \"abc1\"}, {\"Name\": \"def2\"}, {\"Name\": \"ghi3\"}, {\"Name\":\"jkl4\"}]}"
                 ),
                 new Condition(
                     "iterate() must send a GET request",

--- a/src/test/java/com/amihaiemil/docker/LocalDockerITCase.java
+++ b/src/test/java/com/amihaiemil/docker/LocalDockerITCase.java
@@ -25,25 +25,18 @@
  */
 package com.amihaiemil.docker;
 
+import java.io.File;
+import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIterableWithSize;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.internal.matchers.GreaterOrEqual;
-
-import java.io.File;
-import java.nio.file.Paths;
 
 /**
  * Integration tests for LocalDocker.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @todo #241:30min Fix Volumes object return problem. Volumes is returning an
- *  JsonObject instead of JsonArray. Its return must be according its
- *  documentation:
- *  https://docs.docker.com/engine/api/v1.30/#operation/VolumeList and what is
- *  defined in #241.
  * @since 0.0.1
  */
 public final class LocalDockerITCase {
@@ -65,7 +58,6 @@ public final class LocalDockerITCase {
      * @throws Exception If something goes wrong.
      */
     @Test
-    @Ignore
     public void listVolumes() throws Exception {
         final Docker docker = new LocalDocker(
             Paths.get("/var/run/docker.sock").toFile()


### PR DESCRIPTION
For #252:

- Implementing `Volumes.iterate()` differently since Volume API returns JsonObject which holds an array of Volumes objects.