### PR TITLE
For #312: Added test coverage limits to project.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,14 +153,69 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.7.6.201602180812</version>
+                        <version>0.8.5</version>
                         <executions>
                             <execution>
-                                <id>prepare-agent</id>
+                                <id>jacoco-initialize</id>
                                 <goals>
                                     <goal>prepare-agent</goal>
                                 </goals>
                             </execution>
+							<execution>
+								<id>jacoco-check</id>
+								<phase>test</phase>
+								<goals>
+									<goal>check</goal>
+								</goals>
+								<configuration>
+									<rules>
+										<rule>
+											<element>BUNDLE</element>
+											<limits>
+												<limit>
+													<counter>INSTRUCTION
+													</counter>
+													<value>COVEREDRATIO</value>
+													<minimum>0.85</minimum>
+												</limit>
+												<limit>
+													<counter>LINE</counter>
+													<value>COVEREDRATIO</value>
+													<minimum>0.87</minimum>
+												</limit>
+												<limit>
+													<counter>BRANCH</counter>
+													<value>COVEREDRATIO</value>
+													<minimum>0.75</minimum>
+												</limit>
+												<limit>
+													<counter>COMPLEXITY
+													</counter>
+													<value>COVEREDRATIO</value>
+													<minimum>0.84</minimum>
+												</limit>
+												<limit>
+													<counter>METHOD</counter>
+													<value>COVEREDRATIO</value>
+													<minimum>0.85</minimum>
+												</limit>
+												<limit>
+													<counter>CLASS</counter>
+													<value>MISSEDCOUNT</value>
+													<maximum>0</maximum>
+												</limit>
+											</limits>
+										</rule>
+									</rules>
+								</configuration>
+							</execution>
+							<execution>
+								<id>report</id>
+								<phase>test</phase>
+								<goals>
+									<goal>report</goal>
+								</goals>
+							</execution>
                         </executions>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
For #312: Added test coverage limits to project:
- added jacoco plugin to `pom.xml`
- configure jacoco to run on `jacoco` profile
- added coverage limits to the project. As the project now fails when the code coverage is not meet I had to leave some of them below the suggested coverage (0.85)