### PR TITLE
Add call to container/{id}/wait

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Container.java
+++ b/src/main/java/com/amihaiemil/docker/Container.java
@@ -161,7 +161,7 @@ public interface Container extends JsonObject {
      * Wait Container</a>.
      * @throws IOException If something goes wrong.
      *  the expected one (200).
-     * @return the exit code of the container
+     * @return The exit code of the container
      */
     int waitOn(String state) throws IOException;
 

--- a/src/main/java/com/amihaiemil/docker/Container.java
+++ b/src/main/java/com/amihaiemil/docker/Container.java
@@ -151,5 +151,17 @@ public interface Container extends JsonObject {
      *  the expected one (204 NO CONTENT).
      */
     void unpause() throws IOException;
-    
+
+
+    /**
+     * Waits on this container.
+     * @param state The state to wait for. One of "not-running"
+     * (the default if null), "next-exit", or "removed"
+     * @see <a href="https://docs.docker.com/engine/api/v1.35/#operation/ContainerWait">
+     * Wait Container</a>.
+     * @throws IOException If something goes wrong.
+     *  the expected one (200).
+     */
+    void waitOn(String state) throws IOException;
+
 }

--- a/src/main/java/com/amihaiemil/docker/Container.java
+++ b/src/main/java/com/amihaiemil/docker/Container.java
@@ -161,7 +161,8 @@ public interface Container extends JsonObject {
      * Wait Container</a>.
      * @throws IOException If something goes wrong.
      *  the expected one (200).
+     * @return the exit code of the container
      */
-    void waitOn(String state) throws IOException;
+    int waitOn(String state) throws IOException;
 
 }

--- a/src/main/java/com/amihaiemil/docker/RtContainer.java
+++ b/src/main/java/com/amihaiemil/docker/RtContainer.java
@@ -32,7 +32,6 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.message.BasicHeader;
 
 /**
  * Restful Container.
@@ -242,8 +241,6 @@ final class RtContainer extends JsonResource implements Container {
         }
 
         final HttpPost waiter = new HttpPost(urib.build());
-        waiter.setHeader(new BasicHeader("Content-Type", "application/json"));
-
         try {
             final JsonObject json = this.client.execute(
                 waiter,

--- a/src/main/java/com/amihaiemil/docker/RtContainer.java
+++ b/src/main/java/com/amihaiemil/docker/RtContainer.java
@@ -230,4 +230,23 @@ final class RtContainer extends JsonResource implements Container {
             unpause.releaseConnection();
         }
     }
+
+    @Override
+    public void waitOn(final String state) throws IOException {
+        String end = "";
+        if(null == state || state.isEmpty()){
+            end = String.format("?condition=%s", state);
+        }
+        final HttpPost waiter = new HttpPost(
+            this.baseUri.toString() + "/wait" + end
+        );
+        try {
+            this.client.execute(
+                waiter,
+                new MatchStatus(waiter.getURI(), HttpStatus.SC_OK)
+            );
+        } finally {
+            waiter.releaseConnection();
+        }
+    }
 }

--- a/src/main/java/com/amihaiemil/docker/RtContainer.java
+++ b/src/main/java/com/amihaiemil/docker/RtContainer.java
@@ -237,7 +237,7 @@ final class RtContainer extends JsonResource implements Container {
         UncheckedUriBuilder urib = new UncheckedUriBuilder(
             this.baseUri.toString().concat("/wait")
         );
-        if(null == state || state.isEmpty()){
+        if(!(null == state || state.isEmpty())){
             urib.addParameter("condition", state);
         }
 

--- a/src/main/java/com/amihaiemil/docker/UnixDocker.java
+++ b/src/main/java/com/amihaiemil/docker/UnixDocker.java
@@ -34,7 +34,7 @@ import org.apache.http.client.HttpClient;
  * Docker engine.
  *
  * <pre>
- *     final Docker docker = new LocalUnixDocker("unix:///var/run/dicker.sock");
+ *     final Docker docker = new LocalUnixDocker("unix:///var/run/docker.sock");
  * </pre>
  * 
  * This implementation manages an internal pool of 10 http connections. Users


### PR DESCRIPTION
Adds a `container.waitOn()` function to wait for a container to complete. I did not add an integration test because the integration tests do not seem to work on my dev machine (https://github.com/amihaiemil/docker-java-api/issues/303).