### PR TITLE
Stream :: docker.events()

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Docker.java
+++ b/src/main/java/com/amihaiemil/docker/Docker.java
@@ -27,8 +27,11 @@ package com.amihaiemil.docker;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.stream.Stream;
 
 import org.apache.http.client.HttpClient;
+
+import javax.json.JsonObject;
 
 /**
  * Docker API entry point.
@@ -46,13 +49,24 @@ public interface Docker {
     boolean ping() throws IOException;
 
     /**
-     * Follow the events on the server in real time.
-     * @return The events {@link Reader}.
+     * Read events from the server in real time. Pay attention:<br><br>
+     * The Stream is <b>infinite</b>, which means you have to specify a
+     * <b>limit</b> before calling a terminal operation on it. Otherwise,
+     * your terminal operation will run until the Server closes the connection.
+     * Example:
+     * <pre>
+     *   final Docker docker = ...;
+     *   final List&lt;JsonObject&gt; firstTen = docker.events()
+     *       .limit(10).collect(Collectors.toList());
+     *   //It will wait for and return the first 10 real-time events
+     *   //from the server.
+     * </pre>
+     * @return The events as a {@link Stream}.
      * @throws IOException If an I/O error occurs.
      * @throws UnexpectedResponseException If the API responds with an
      *  unexpected status.
      */
-    Reader events()
+    Stream<JsonObject> events()
         throws IOException, UnexpectedResponseException;
 
     /**

--- a/src/main/java/com/amihaiemil/docker/Docker.java
+++ b/src/main/java/com/amihaiemil/docker/Docker.java
@@ -26,7 +26,6 @@
 package com.amihaiemil.docker;
 
 import java.io.IOException;
-import java.io.Reader;
 import java.util.stream.Stream;
 
 import org.apache.http.client.HttpClient;

--- a/src/test/java/com/amihaiemil/docker/LocalDockerITCase.java
+++ b/src/test/java/com/amihaiemil/docker/LocalDockerITCase.java
@@ -28,14 +28,20 @@ package com.amihaiemil.docker;
 import java.io.File;
 import java.io.Reader;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.http.util.EntityUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIterableWithSize;
 import org.junit.Test;
 import org.junit.Ignore;
 import org.mockito.internal.matchers.GreaterOrEqual;
+
+import javax.json.JsonObject;
 
 /**
  * Integration tests for LocalUnixDocker.
@@ -56,24 +62,19 @@ public final class LocalDockerITCase {
         );
         MatcherAssert.assertThat(docker.ping(), Matchers.is(Boolean.TRUE));
     }
+
     /**
-     * Docker can follow the events stream. Ignored for now,
-     * doesn't work yet.
+     * Docker can return its events Stream.
      * @throws Exception If something goes wrong.
      */
     @Test
-    //@Ignore
-    public void followsEvents() throws Exception {
-        final Reader reader =  new LocalDocker(
+    public void returnsEvents() throws Exception {
+        final Stream<JsonObject> events = new LocalDocker(
             new File("/var/run/docker.sock")
         ).events();
-        final String events = IOUtils.toString(reader);
-        System.out.println(events);
-        MatcherAssert.assertThat(
-            events.trim(),
-            Matchers.notNullValue()
-        );
+        MatcherAssert.assertThat(events, Matchers.notNullValue());
     }
+
     /**
      * LocalUnixDocker can list {@link Volumes}.
      * @throws Exception If something goes wrong.

--- a/src/test/java/com/amihaiemil/docker/LocalDockerITCase.java
+++ b/src/test/java/com/amihaiemil/docker/LocalDockerITCase.java
@@ -62,15 +62,16 @@ public final class LocalDockerITCase {
      * @throws Exception If something goes wrong.
      */
     @Test
-    @Ignore
+    //@Ignore
     public void followsEvents() throws Exception {
         final Reader reader =  new LocalDocker(
             new File("/var/run/docker.sock")
         ).events();
         final String events = IOUtils.toString(reader);
+        System.out.println(events);
         MatcherAssert.assertThat(
-                events.trim(),
-                Matchers.notNullValue()
+            events.trim(),
+            Matchers.notNullValue()
         );
     }
     /**

--- a/src/test/java/com/amihaiemil/docker/LocalDockerITCase.java
+++ b/src/test/java/com/amihaiemil/docker/LocalDockerITCase.java
@@ -26,19 +26,13 @@
 package com.amihaiemil.docker;
 
 import java.io.File;
-import java.io.Reader;
 import java.nio.file.Paths;
-import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.http.util.EntityUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIterableWithSize;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.mockito.internal.matchers.GreaterOrEqual;
 
 import javax.json.JsonObject;

--- a/src/test/java/com/amihaiemil/docker/UnixDockerITCase.java
+++ b/src/test/java/com/amihaiemil/docker/UnixDockerITCase.java
@@ -28,6 +28,7 @@ package com.amihaiemil.docker;
 import java.io.File;
 import java.io.Reader;
 import java.nio.file.Paths;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
@@ -36,6 +37,8 @@ import org.hamcrest.collection.IsIterableWithSize;
 import org.junit.Test;
 import org.junit.Ignore;
 import org.mockito.internal.matchers.GreaterOrEqual;
+
+import javax.json.JsonObject;
 
 /**
  * Integration tests for LocalUnixDocker.
@@ -56,23 +59,19 @@ public final class UnixDockerITCase {
         );
         MatcherAssert.assertThat(docker.ping(), Matchers.is(Boolean.TRUE));
     }
+
     /**
-     * Docker can follow the events stream. Ignored for now,
-     * doesn't work yet.
+     * Docker can return its events Stream.
      * @throws Exception If something goes wrong.
      */
     @Test
-    @Ignore
-    public void followsEvents() throws Exception {
-        final Reader reader =  new UnixDocker(
+    public void returnsEvents() throws Exception {
+        final Stream<JsonObject> events = new UnixDocker(
             new File("/var/run/docker.sock")
         ).events();
-        final String events = IOUtils.toString(reader);
-        MatcherAssert.assertThat(
-                events.trim(),
-                Matchers.notNullValue()
-        );
+        MatcherAssert.assertThat(events, Matchers.notNullValue());
     }
+
     /**
      * UnixDocker can list {@link Volumes}.
      * @throws Exception If something goes wrong.

--- a/src/test/java/com/amihaiemil/docker/UnixDockerITCase.java
+++ b/src/test/java/com/amihaiemil/docker/UnixDockerITCase.java
@@ -26,16 +26,13 @@
 package com.amihaiemil.docker;
 
 import java.io.File;
-import java.io.Reader;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIterableWithSize;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.mockito.internal.matchers.GreaterOrEqual;
 
 import javax.json.JsonObject;


### PR DESCRIPTION
PR for #299 

* Docker.events() returns an infinite Stream of JsonObject events (added JavaDocs about the call to ``Stream.limit()`` being mandatory).
