### PR TITLE
#299 Events/RtEvents implemented; needs tests

### DIFF
--- a/src/main/java/com/amihaiemil/docker/Docker.java
+++ b/src/main/java/com/amihaiemil/docker/Docker.java
@@ -26,11 +26,7 @@
 package com.amihaiemil.docker;
 
 import java.io.IOException;
-import java.util.stream.Stream;
-
 import org.apache.http.client.HttpClient;
-
-import javax.json.JsonObject;
 
 /**
  * Docker API entry point.
@@ -48,25 +44,10 @@ public interface Docker {
     boolean ping() throws IOException;
 
     /**
-     * Read events from the server in real time. Pay attention:<br><br>
-     * The Stream is <b>infinite</b>, which means you have to specify a
-     * <b>limit</b> before calling a terminal operation on it. Otherwise,
-     * your terminal operation will run until the Server closes the connection.
-     * Example:
-     * <pre>
-     *   final Docker docker = ...;
-     *   final List&lt;JsonObject&gt; firstTen = docker.events()
-     *       .limit(10).collect(Collectors.toList());
-     *   //It will wait for and return the first 10 real-time events
-     *   //from the server.
-     * </pre>
-     * @return The events as a {@link Stream}.
-     * @throws IOException If an I/O error occurs.
-     * @throws UnexpectedResponseException If the API responds with an
-     *  unexpected status.
+     * Entry point for the Events API.
+     * @return Events.
      */
-    Stream<JsonObject> events()
-        throws IOException, UnexpectedResponseException;
+    Events events();
 
     /**
      * Entry point for the Containers API.

--- a/src/main/java/com/amihaiemil/docker/Events.java
+++ b/src/main/java/com/amihaiemil/docker/Events.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2018-2020, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.amihaiemil.docker;
+
+import javax.json.JsonObject;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * Events API.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.13
+ */
+public interface Events {
+
+    /**
+     * Show events created since the specified timestamp,
+     * then stream new events.
+     * @param timestamp Given timestamp.
+     * @return Filtered Events.
+     */
+    Events since(final LocalDateTime timestamp);
+
+    /**
+     * Show events created until the specified timestamp,
+     * then stop streaming.
+     * @param timestamp Given timestamp.
+     * @return Filtered Events.
+     */
+    Events until(final LocalDateTime timestamp);
+
+    /**
+     * Filter these Events.
+     * @param filter Supplier of filters.
+     * @return Filtered Events.
+     * @see <a href="https://docs.docker.com/engine/api/v1.40/#operation/SystemEvents">Docker API Docs</a>
+     */
+    Events filter(final Supplier<Map<String, Iterable<String>>> filter);
+
+    /**
+     * Start monitoring these events. Pay attention:<br><br>
+     * The Stream is <b>infinite</b>, which means you have to specify a
+     * <b>limit</b> before calling a terminal operation on it. Otherwise,
+     * your terminal operation will run until the Server closes the connection.
+     * Example:
+     * <pre>
+     *   final Docker docker = ...;
+     *   final List&lt;JsonObject&gt; firstTen = docker.events().monitor()
+     *       .limit(10).collect(Collectors.toList());
+     *   //It will wait for and return the first 10 real-time events
+     *   //from the server.
+     * </pre>
+     * @throws IOException If there is any I/O problem.
+     * @throws UnexpectedResponseException If the response is not 200 OK.
+     * @return Stream of events.
+     */
+    Stream<JsonObject> monitor()
+        throws IOException, UnexpectedResponseException;
+
+    /**
+     * Docker where these events came from.
+     * @return Docker.
+     */
+    Docker docker();
+}

--- a/src/main/java/com/amihaiemil/docker/RtEvents.java
+++ b/src/main/java/com/amihaiemil/docker/RtEvents.java
@@ -1,0 +1,272 @@
+/**
+ * Copyright (c) 2018-2020, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of docker-java-api nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.amihaiemil.docker;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * RESTful Events API.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.13
+ */
+final class RtEvents implements Events {
+    /**
+     * Events filters.
+     */
+    private final Map<String, Iterable<String>> filters;
+
+    /**
+     * Since tim
+     * estamp.
+     */
+    private final LocalDateTime since;
+
+    /**
+     * Until timestamp.
+     */
+    private final LocalDateTime until;
+
+    /**
+     * Apache HttpClient which sends the requests.
+     */
+    private final HttpClient client;
+
+    /**
+     * Base URI.
+     */
+    private final URI baseUri;
+
+    /**
+     * Docker API.
+     */
+    private final Docker docker;
+
+    /**
+     * Ctor.
+     * @param client Given HTTP Client.
+     * @param baseUri Base URI, ending with /containers.
+     * @param dkr Docker where these Containers are from.
+     */
+    RtEvents(final HttpClient client, final URI baseUri, final Docker dkr) {
+        this(client, baseUri, dkr, new HashMap<>(), null, null);
+    }
+
+    /**
+     * Ctor.
+     * @param client Given HTTP Client.
+     * @param baseUri Base URI, ending with /containers.
+     * @param dkr Docker where these Containers are from.
+     * @param filters Filters to apply on these events.
+     * @param since Since timestamp.
+     * @param until Until timestamp.
+     * @checkstyle ParameterNumber (2 lines)
+     */
+    RtEvents(
+        final HttpClient client, final URI baseUri, final Docker dkr,
+        final Map<String, Iterable<String>> filters,
+        final LocalDateTime since,
+        final LocalDateTime until
+    ) {
+        this.client = client;
+        this.baseUri = baseUri;
+        this.docker = dkr;
+        this.filters = filters;
+        this.since = since;
+        this.until = until;
+    }
+
+    @Override
+    public Events since(final LocalDateTime timestamp) {
+        return new RtEvents(
+            this.client,
+            this.baseUri,
+            this.docker,
+            this.filters,
+            timestamp,
+            this.until
+        );
+    }
+
+    @Override
+    public Events until(final LocalDateTime timestamp) {
+        return new RtEvents(
+            this.client,
+            this.baseUri,
+            this.docker,
+            this.filters,
+            this.since,
+            timestamp
+        );
+    }
+
+    @Override
+    public Events filter(
+        final Supplier<Map<String, Iterable<String>>> filter
+    ) {
+        final Map<String, Iterable<String>> merged = new HashMap<>(
+            this.filters
+        );
+        merged.putAll(filter.get());
+        return new RtEvents(
+            this.client,
+            this.baseUri,
+            this.docker,
+            merged,
+            this.since,
+            this.until
+        );
+    }
+
+    /**
+     * Unlike other methods, we cannot implement this one using Response
+     * Handlers, because Apache HTTP Client tries to consume the remaining
+     * content after all the handlers have been executed, which results in
+     * a blockage, since the underlying InputStream is potentially infinite.
+     *
+     * @checkstyle CommentsIndentation (100 lines)
+     * @checkstyle Indentation (100 lines)
+     * @return Stream of Events.
+     * @throws IOException If any I/O problem occurs.
+     * @throws UnexpectedResponseException If the response status is not 200.
+     */
+    @Override
+    public Stream<JsonObject> monitor()
+        throws IOException, UnexpectedResponseException {
+        final HttpGet monitor = new HttpGet(this.buildMonitorUri());
+        final HttpResponse response = this.client.execute(monitor);
+        final int actual = response.getStatusLine().getStatusCode();
+        if(actual != HttpStatus.SC_OK) {
+            throw new UnexpectedResponseException(
+                this.buildMonitorUri().toString(),
+                actual, HttpStatus.SC_OK,
+                Json.createObjectBuilder().build()
+            );
+        } else {
+            final InputStream content = response.getEntity().getContent();
+            final Stream<JsonObject> stream = Stream.generate(
+                () -> {
+                    JsonObject read = null;
+                    try {
+                        final byte[] tmp = new byte[4096];
+                        while (content.read(tmp) != -1) {
+                            try {
+                                final JsonReader reader = Json.createReader(
+                                    new ByteArrayInputStream(tmp)
+                                );
+                                read = reader.readObject();
+                                break;
+                            //@checkstyle IllegalCatch (1 line)
+                            } catch (final Exception exception) {
+                                //Couldn't parse byte[] to Json,
+                                //try to read more bytes.
+                            }
+                        }
+                    } catch (final IOException ex) {
+                        throw new IllegalStateException(
+                            "IOException when reading streamed JsonObjects!"
+                        );
+                    }
+                    return read;
+                }
+            ).onClose(
+                () -> {
+                    try {
+                        ((CloseableHttpResponse) response).close();
+                    } catch (final IOException ex) {
+                        //There is a bug in Apache HTTPClient, when closing
+                        //an infinite InputStream: IOException is thrown
+                        //because the client still tries to read the remainder
+                        // of the closed Stream. We should ignore this case.
+                    }
+                }
+            );
+            return stream;
+        }
+    }
+
+    @Override
+    public Docker docker() {
+        return this.docker;
+    }
+
+    /**
+     * Build up the URI for the monitoring operation.
+     * Add the since/until query params if they are present
+     * and also add the filters.
+     * @return URI.
+     */
+    private URI buildMonitorUri() {
+        final URIBuilder uriBuilder = new UncheckedUriBuilder(
+                this.baseUri.toString()
+        );
+        if (this.since != null) {
+            uriBuilder.addParameter(
+                "since",
+                String.valueOf(
+                    ZonedDateTime.of(
+                        this.since, ZoneId.systemDefault()
+                    ).toInstant().toEpochMilli()
+                )
+            );
+        }
+        if (this.until != null) {
+            uriBuilder.addParameter(
+                "until",
+                String.valueOf(
+                    ZonedDateTime.of(
+                        this.until, ZoneId.systemDefault()
+                    ).toInstant().toEpochMilli()
+                )
+            );
+        }
+        final FilteredUriBuilder uri = new FilteredUriBuilder(
+            uriBuilder,
+            this.filters
+        );
+        return uri.build();
+    }
+}

--- a/src/test/java/com/amihaiemil/docker/LocalDockerITCase.java
+++ b/src/test/java/com/amihaiemil/docker/LocalDockerITCase.java
@@ -53,19 +53,7 @@ public final class LocalDockerITCase {
         );
         MatcherAssert.assertThat(docker.ping(), Matchers.is(Boolean.TRUE));
     }
-
-    /**
-     * Docker can return its Events.
-     * @throws Exception If something goes wrong.
-     */
-    @Test
-    public void returnsEvents() throws Exception {
-        final Events events = new LocalDocker(
-            new File("/var/run/docker.sock")
-        ).events();
-        MatcherAssert.assertThat(events, Matchers.notNullValue());
-    }
-
+    
     /**
      * LocalUnixDocker can list {@link Volumes}.
      * @throws Exception If something goes wrong.

--- a/src/test/java/com/amihaiemil/docker/LocalDockerITCase.java
+++ b/src/test/java/com/amihaiemil/docker/LocalDockerITCase.java
@@ -27,15 +27,12 @@ package com.amihaiemil.docker;
 
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.stream.Stream;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIterableWithSize;
 import org.junit.Test;
 import org.mockito.internal.matchers.GreaterOrEqual;
-
-import javax.json.JsonObject;
 
 /**
  * Integration tests for LocalUnixDocker.
@@ -58,12 +55,12 @@ public final class LocalDockerITCase {
     }
 
     /**
-     * Docker can return its events Stream.
+     * Docker can return its Events.
      * @throws Exception If something goes wrong.
      */
     @Test
     public void returnsEvents() throws Exception {
-        final Stream<JsonObject> events = new LocalDocker(
+        final Events events = new LocalDocker(
             new File("/var/run/docker.sock")
         ).events();
         MatcherAssert.assertThat(events, Matchers.notNullValue());

--- a/src/test/java/com/amihaiemil/docker/UnixDockerITCase.java
+++ b/src/test/java/com/amihaiemil/docker/UnixDockerITCase.java
@@ -26,13 +26,21 @@
 package com.amihaiemil.docker;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIterableWithSize;
 import org.junit.Test;
 import org.mockito.internal.matchers.GreaterOrEqual;
+
+import javax.json.JsonObject;
 
 /**
  * Integration tests for LocalUnixDocker.
@@ -55,15 +63,155 @@ public final class UnixDockerITCase {
     }
 
     /**
-     * Docker can return its Events.
+     * Docker can return its Events unfiltered.
      * @throws Exception If something goes wrong.
      */
     @Test
-    public void returnsEvents() throws Exception {
-        final Events events = new UnixDocker(
-            new File("/var/run/docker.sock")
-        ).events();
-        MatcherAssert.assertThat(events, Matchers.notNullValue());
+    public void returnsUnfilteredEvents() throws Exception {
+        final Thread pull = new Thread(
+            () -> {
+                try {
+                    Thread.sleep(2000);
+                    final Image img = new UnixDocker(
+                        new File("/var/run/docker.sock")
+                    ).images().pull("hello-world", "latest");
+                } catch (final IOException | InterruptedException ex) {
+                    throw new IllegalStateException(ex);
+                }
+            }
+        );
+        pull.start();
+        try {
+            final Events events = new UnixDocker(
+                new File("/var/run/docker.sock")
+            ).events();
+            final JsonObject pulled = events
+                .monitor()
+                .limit(1)
+                .collect(Collectors.toList())
+                .get(0);
+            MatcherAssert.assertThat(
+                pulled.getString("status"),
+                Matchers.equalTo("pull")
+            );
+            MatcherAssert.assertThat(
+                pulled.getString("id"),
+                Matchers.equalTo("hello-world:latest")
+            );
+        } finally {
+            pull.stop();
+        }
+    }
+
+    /**
+     * Docker can return its Events with filtering at streaming time.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void returnsFilteredStreamOfEvents() throws Exception {
+        final Thread pull = new Thread(
+            () -> {
+                try {
+                    Thread.sleep(2000);
+                    final Images images = new UnixDocker(
+                        new File("/var/run/docker.sock")
+                    ).images();
+                    images.pull("hello-world", "latest");
+                    images.pull("ubuntu", "latest");
+                    images.pull("hello-world", "latest");
+                    images.pull("ubuntu", "latest");
+                } catch (final IOException | InterruptedException ex) {
+                    throw new IllegalStateException(ex);
+                }
+            }
+        );
+        pull.start();
+        try {
+            final Events events = new UnixDocker(
+                new File("/var/run/docker.sock")
+            ).events();
+            final List<JsonObject> pulled = events
+                .monitor()
+                .filter(json -> json.getString("id").startsWith("ubuntu"))
+                .limit(2)
+                .collect(Collectors.toList());
+            MatcherAssert.assertThat(
+                pulled,
+                Matchers.iterableWithSize(2)
+            );
+            MatcherAssert.assertThat(
+                pulled.get(0).getString("id"),
+                Matchers.equalTo("ubuntu:latest")
+            );
+            MatcherAssert.assertThat(
+                pulled.get(1).getString("id"),
+                Matchers.equalTo("ubuntu:latest")
+            );
+        } finally {
+            pull.stop();
+        }
+    }
+
+    /**
+     * Docker can return its Events which are filter at request time.
+     * @checkstyle LineLength (100 lines)
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void returnsFilteredEvents() throws Exception {
+        final Thread pull = new Thread(
+            () -> {
+                try {
+                    Thread.sleep(2000);
+                    final Container started = new UnixDocker(
+                        new File("/var/run/docker.sock")
+                    ).images().pull("hello-world", "latest").run();
+                } catch (final IOException | InterruptedException ex) {
+                    throw new IllegalStateException(ex);
+                }
+            }
+        );
+        pull.start();
+        try {
+            final Events events = new UnixDocker(
+                new File("/var/run/docker.sock")
+            ).events();
+            final List<JsonObject> streamed = events
+                .filter(
+                    () -> {
+                        final Map<String, Iterable<String>> filters = new HashMap<>();
+                        filters.put("type", Arrays.asList("container"));
+                        return filters;
+                    }
+                )
+                .monitor()
+                .limit(3)
+                .collect(Collectors.toList());
+            MatcherAssert.assertThat(
+                streamed,
+                Matchers.iterableWithSize(3)
+            );
+            for(final JsonObject event : streamed) {
+                MatcherAssert.assertThat(
+                    event.getString("Type"),
+                    Matchers.equalTo("container")
+                );
+            }
+            MatcherAssert.assertThat(
+                streamed.get(0).getString("status"),
+                Matchers.equalTo("create")
+            );
+            MatcherAssert.assertThat(
+                streamed.get(1).getString("status"),
+                Matchers.equalTo("start")
+            );
+            MatcherAssert.assertThat(
+                streamed.get(2).getString("status"),
+                Matchers.equalTo("die")
+            );
+        } finally {
+            pull.stop();
+        }
     }
 
     /**

--- a/src/test/java/com/amihaiemil/docker/UnixDockerITCase.java
+++ b/src/test/java/com/amihaiemil/docker/UnixDockerITCase.java
@@ -27,15 +27,12 @@ package com.amihaiemil.docker;
 
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.stream.Stream;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIterableWithSize;
 import org.junit.Test;
 import org.mockito.internal.matchers.GreaterOrEqual;
-
-import javax.json.JsonObject;
 
 /**
  * Integration tests for LocalUnixDocker.
@@ -58,12 +55,12 @@ public final class UnixDockerITCase {
     }
 
     /**
-     * Docker can return its events Stream.
+     * Docker can return its Events.
      * @throws Exception If something goes wrong.
      */
     @Test
     public void returnsEvents() throws Exception {
-        final Stream<JsonObject> events = new UnixDocker(
+        final Events events = new UnixDocker(
             new File("/var/run/docker.sock")
         ).events();
         MatcherAssert.assertThat(events, Matchers.notNullValue());


### PR DESCRIPTION
PR for #299 

We cannot expose a Stream directly, we need to let the user specify the query parameters as well. Thus, we need the ``Events`` abstraction.

Still needs unit tests.